### PR TITLE
Fix POD for SQL_BIGINT type constant

### DIFF
--- a/DBI.pm
+++ b/DBI.pm
@@ -2604,8 +2604,8 @@ produced like this:
   }
 
 These constants are defined by SQL/CLI, ODBC or both.
-C<SQL_BIGINT> is (currently) omitted, because SQL/CLI and ODBC provide
-conflicting codes.
+C<SQL_BIGINT> has conflicting codes in SQL/CLI and ODBC,
+DBI uses the ODBC one.
 
 See the L</type_info>, L</type_info_all>, and L</bind_param> methods
 for possible uses.


### PR DESCRIPTION
It's exported as of DBI-1.54, with the ODBC value.
