### PR TITLE
move optional deps to "suggest"

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -65,7 +65,7 @@ my %opts = (
 	    license     => 'http://dev.perl.org/licenses/',
 	    homepage    => 'http://dbi.perl.org/',
 	},
-	recommends => {
+	suggests => {
 	    'RPC::PlServer'  => 0.2001,
 	    'Net::Daemon'    => 0,
 	    'SQL::Statement' => 1.402,


### PR DESCRIPTION
@shadowcat-mst suggested that these should be moved to 'suggests', to avoid automatic installation from toolchains that have '--with-recommends' in the default cpanm argument list.
