### PR TITLE
Update Proxy.pm - POD changes

### DIFF
--- a/lib/DBD/Proxy.pm
+++ b/lib/DBD/Proxy.pm
@@ -759,7 +759,6 @@ proxying the connect_cached method. The proxy server will hold the
 database connections open in a cache. The CGI script then trades the
 database connect/disconnect overhead for the DBD::Proxy
 connect/disconnect overhead which is typically much less.
-I<Note that the connect_cached method is new and still experimental.>
 
 
 =head1 CONNECTING TO THE DATABASE
@@ -846,7 +845,7 @@ less secure than the usercipher/userkey secret and readable by anyone.
 The usercipher/userkey secret is B<your> private secret.
 
 Of course encryption requires an appropriately configured server. See
-<DBD::ProxyServer/CONFIGURATION FILE>.
+L<DBD::ProxyServer/CONFIGURATION FILE>.
 
 =item debug
 


### PR DESCRIPTION
Remove the note 'that the connect_cached method is new and still experimental.'
Fix link to DBD::ProxyServer/CONFIGURATION FILE
