### PR TITLE
DBD::Sponge corrected and lazy default PRECISION 

### DIFF
--- a/lib/DBD/Sponge.pm
+++ b/lib/DBD/Sponge.pm
@@ -219,6 +219,8 @@ use warnings;
     }
 
     sub _max_col_lengths {
+	# Compute result set PRECISION (data length) by looking for the
+	# max lengths of each column's data.
 	my ($numFields, $rows) = @_;
 	my @precision = (0,) x $numFields;
 	my $len;
@@ -280,33 +282,38 @@ No username and password are needed.
 
 =item *
 
-The C<$statement> here is an arbitrary statement or name you want
-to provide as identity of your data. If you're using DBI::Profile
-it will appear in the profile data.
+The C<$statement> here is an arbitrary statement or name you want to
+provide as identity of your data. If you're using DBI::Profile it will
+appear in the profile data.
 
-Generally it's expected that you are preparing a statement handle
-as if a C<select> statement happened.
-
-=item *
-
-C<$data> is a reference to the data you are providing, given as an array of arrays.
+Generally it's expected that you are preparing a statement handle as if
+a C<select> statement happened.
 
 =item *
 
-C<$names> is a reference an array of column names for the C<$data> you are providing.
-The number and order should match the number and ordering of the C<$data> columns.
+C<$data> is a reference to the data you are providing, given as an array
+of arrays.
 
 =item *
 
-C<%attr> is a hash of other standard DBI attributes that you might pass to a prepare statement.
+C<$names> is a reference an array of column names for the C<$data> you
+are providing.  The number and order should match the number and
+ordering of the C<$data> columns.
 
-Currently only NAME, TYPE, and PRECISION are supported.  PRECISION will be automatically computed if not supplied.
+=item *
+
+C<%attr> is a hash of other standard DBI attributes that you might pass
+to a prepare statement.
+
+Currently only NAME, TYPE, and PRECISION are supported.  TYPE defaults
+to SQL_VARCHAR.  PRECISION will be lazily computed if not supplied.
 
 =back
 
 =head1 BUGS
 
-Using this module to prepare INSERT-like statements is not currently documented.
+Using this module to prepare INSERT-like statements is not currently
+documented.
 
 =head1 AUTHOR AND COPYRIGHT
 

--- a/lib/DBD/Sponge.pm
+++ b/lib/DBD/Sponge.pm
@@ -93,12 +93,13 @@ use warnings;
 		    || [ map { "col$_" } 1..$numFields ];
 	    $sth->{TYPE} = $attribs->{TYPE}
 		    || [ (DBI::SQL_VARCHAR()) x $numFields ];
-	    $sth->{PRECISION} = $attribs->{PRECISION}
-		    || _max_columnar_lengths($numFields, $rows);
 	    $sth->{SCALE} = $attribs->{SCALE}
 		    || [ (0) x $numFields ];
 	    $sth->{NULLABLE} = $attribs->{NULLABLE}
 		    || [ (2) x $numFields ];
+	    if ($attribs->{PRECISION}) {
+		    $sth->{PRECISION} = $attribs->{PRECISION};
+	    } # else FETCH will dynamically compute
 	}
 
 	$outer;
@@ -155,18 +156,6 @@ use warnings;
 	return \@args;
     }
 
-    sub _max_columnar_lengths {
-	my ($numFields, $rows) = @_;
-	my @precision = (0,) x $numFields;
-	my $len;
-	for my $row (@$rows) {
-	    for my $i (0 .. $numFields - 1) {
-		next unless defined $len = length($row->[$i]);
-		$precision[$i] = $len if $len > $precision[$i];
-	    }
-	}
-	return wantarray ? @precision : \@precision;
-    }
 }
 
 
@@ -214,6 +203,10 @@ use warnings;
     sub FETCH {
 	my ($sth, $attrib) = @_;
 	# would normally validate and only fetch known attributes
+	if ($attrib eq 'PRECISION') {
+	    # prepare() did _not_ specify PRECISION.  We'll only get here once.
+	    return $sth->{PRECISION} = _max_col_lengths(@{$sth}{'NUM_OF_FIELDS', 'rows'});
+	}
 	# else pass up to DBI to handle
 	return $sth->SUPER::FETCH($attrib);
     }
@@ -223,6 +216,19 @@ use warnings;
 	# would normally validate and only store known attributes
 	# else pass up to DBI to handle
 	return $sth->SUPER::STORE($attrib, $value);
+    }
+
+    sub _max_col_lengths {
+	my ($numFields, $rows) = @_;
+	my @precision = (0,) x $numFields;
+	my $len;
+	for my $row (@$rows) {
+	    for my $i (0 .. $numFields - 1) {
+		next unless defined($len = length($row->[$i]));
+		$precision[$i] = $len if $len > $precision[$i];
+	    }
+	}
+	return wantarray ? @precision : \@precision;
     }
 }
 

--- a/t/xx_sponge.t
+++ b/t/xx_sponge.t
@@ -1,0 +1,52 @@
+#! /usr/bin/env perl
+
+# vim: noet ts=2 sw=2:
+
+use strict;
+use warnings;
+use Test::More tests => 17;
+
+use Storable qw(dclone);
+use DBI qw(:sql_types);
+
+our @ROWS = (['foo',     undef,       'bazooka'],
+             ['foolery', 'bar',       undef    ],
+             [undef,     'barrowman', 'baz'    ]);
+
+my $dbh = DBI->connect("dbi:Sponge:", '', '');
+ok($dbh, "connect(dbi:Sponge:) succeeds");
+
+my $sth = $dbh->prepare("simple, correct sponge", {
+                        rows => dclone( \@ROWS ),
+                        NAME => [ qw(A0 B1 C2) ],
+                        });
+
+ok($sth, "prepare() of 3x3 result succeeded");
+is_deeply($sth->{NAME}, ['A0', 'B1', 'C2'], "column NAMEs as expected");
+is_deeply($sth->{TYPE}, [SQL_VARCHAR, SQL_VARCHAR, SQL_VARCHAR],
+          "column TYPEs default to SQL_VARCHAR");
+is_deeply($sth->{PRECISION}, [7, 9, 7],
+          "column PRECISION matches lengths of longest field data");
+is_deeply($sth->fetch(), $ROWS[0], "first row fetch as expected");
+is_deeply($sth->fetch(), $ROWS[1], "second row fetch as expected");
+is_deeply($sth->fetch(), $ROWS[2], "third row fetch as expected");
+ok(!defined($sth->fetch()), "fourth fetch returns undef");
+
+
+$sth = $dbh->prepare('user-supplied silly TYPE and PRECISION', {
+                     rows => dclone( \@ROWS ),
+                     NAME => [qw( first_col second_col third_col )],
+                     TYPE => [SQL_INTEGER, SQL_DATETIME, SQL_CHAR],
+                     PRECISION => [1, 100_000, 0],
+                     });
+ok($sth, "prepare() 3x3 result with TYPE and PRECISION succeeded");
+is_deeply($sth->{NAME}, ['first_col','second_col','third_col'],
+          "column NAMEs again as expected");
+is_deeply($sth->{TYPE}, [SQL_INTEGER, SQL_DATETIME, SQL_CHAR],
+          "column TYPEs not overwritten");
+is_deeply($sth->{PRECISION}, [1, 100_000, 0],
+          "column PRECISION not overwritten");
+is_deeply($sth->fetch(), $ROWS[0], "first row fetch as expected, despite bogus attributes");
+is_deeply($sth->fetch(), $ROWS[1], "second row fetch as expected, despite bogus attributes");
+is_deeply($sth->fetch(), $ROWS[2], "third row fetch as expected, despite bogus attributes");
+ok(!defined($sth->fetch()), "fourth fetch returns undef, despite bogus attributes");

--- a/t/xx_sponge.t
+++ b/t/xx_sponge.t
@@ -9,22 +9,36 @@ use Test::More tests => 17;
 use Storable qw(dclone);
 use DBI qw(:sql_types);
 
-our @ROWS = (['foo',     undef,       'bazooka'],
-             ['foolery', 'bar',       undef    ],
-             [undef,     'barrowman', 'baz'    ]);
+# our reference table:
+#
+#   A1      B1        C2
+#  ------- --------- -------
+#  foo     NULL      bazooka
+#  foolery bar       NULL
+#  NULL    barrowman baz
+#
+
+our @NAMES = ( 'A0',      'B1',        'C2'      );
+our @ROWS  = (['foo',     undef,       'bazooka'],
+              ['foolery', 'bar',       undef    ],
+              [undef,     'barrowman', 'baz'    ]);
 
 my $dbh = DBI->connect("dbi:Sponge:", '', '');
 ok($dbh, "connect(dbi:Sponge:) succeeds");
 
 my $sth = $dbh->prepare("simple, correct sponge", {
                         rows => dclone( \@ROWS ),
-                        NAME => [ qw(A0 B1 C2) ],
+                        NAME => [ @NAMES ],
                         });
 
 ok($sth, "prepare() of 3x3 result succeeded");
 is_deeply($sth->{NAME}, ['A0', 'B1', 'C2'], "column NAMEs as expected");
 is_deeply($sth->{TYPE}, [SQL_VARCHAR, SQL_VARCHAR, SQL_VARCHAR],
           "column TYPEs default to SQL_VARCHAR");
+#
+# Old versions of DBD-Sponge defaulted PRECISION (data "length") to
+# length of the field _names_ rather than the length of the _data_.
+#
 is_deeply($sth->{PRECISION}, [7, 9, 7],
           "column PRECISION matches lengths of longest field data");
 is_deeply($sth->fetch(), $ROWS[0], "first row fetch as expected");
@@ -32,7 +46,7 @@ is_deeply($sth->fetch(), $ROWS[1], "second row fetch as expected");
 is_deeply($sth->fetch(), $ROWS[2], "third row fetch as expected");
 ok(!defined($sth->fetch()), "fourth fetch returns undef");
 
-
+# Test that DBD-Sponge preserves bogus user-supplied attributes
 $sth = $dbh->prepare('user-supplied silly TYPE and PRECISION', {
                      rows => dclone( \@ROWS ),
                      NAME => [qw( first_col second_col third_col )],

--- a/t/xx_sponge.t
+++ b/t/xx_sponge.t
@@ -11,12 +11,17 @@ use DBI qw(:sql_types);
 
 # our reference table:
 #
-#   A1      B1        C2
+#   A0      B1        C2
 #  ------- --------- -------
 #  foo     NULL      bazooka
 #  foolery bar       NULL
 #  NULL    barrowman baz
 #
+
+# Historically, DBD::Sponge defaulted an sth's PRECISION to the length
+# of its column names, meaning that some DBI shells could truncate row
+# display.  For example, formatting a row ('fo', NULL, 'ba') from our
+# reference table above.
 
 our @NAMES = ( 'A0',      'B1',        'C2'      );
 our @ROWS  = (['foo',     undef,       'bazooka'],
@@ -46,7 +51,8 @@ is_deeply($sth->fetch(), $ROWS[1], "second row fetch as expected");
 is_deeply($sth->fetch(), $ROWS[2], "third row fetch as expected");
 ok(!defined($sth->fetch()), "fourth fetch returns undef");
 
-# Test that DBD-Sponge preserves bogus user-supplied attributes
+# Test that DBD-Sponge preserves bogus user-supplied attributes but
+# ignores them when returning rows
 $sth = $dbh->prepare('user-supplied silly TYPE and PRECISION', {
                      rows => dclone( \@ROWS ),
                      NAME => [qw( first_col second_col third_col )],


### PR DESCRIPTION
DBD::Sponge defaults statement handle PRECISION to the length of column NAMEs, which means that a result set's PRECISION can be nonsensically smaller than would actually be required for the data:

```
$sponge->prepare("sponges",
                 { NAME =>   ['phylum',   'class'],                # PRECISION defaults to [6,5]
                   rows => [ ['Porifera', 'Hexactinellida'], ] }); # but data would need at least [8,14]
```

This request changes that default to the columnar maximum lengths of the data, computed only if needed.  Test cases and small POD update.  (Noticed this playing with yet another DBI::Shell alternative.)
