### PR TITLE
add multi_ prefix for DBD::Multi as negotiated

### DIFF
--- a/DBI.pm
+++ b/DBI.pm
@@ -348,6 +348,7 @@ my $dbd_prefix_registry = {
   mo_          => { class => 'DBD::MO',             },
   monetdb_     => { class => 'DBD::monetdb',        },
   msql_        => { class => 'DBD::mSQL',           },
+  multi_       => { class => 'DBD::Multi',          },
   mvsftp_      => { class => 'DBD::MVS_FTPSQL',     },
   mysql_       => { class => 'DBD::mysql',          },
   mx_          => { class => 'DBD::Multiplex',      },


### PR DESCRIPTION
as negotiated in RT#93204 this add's a multi_ prefix for Dan's DBD::Multi.
Thanks for mje@ reminding us.

I didn't add a Changes entry to avoid conflict with Tux' dbd-file-TYPE branch
