### PR TITLE
Care for different Table class where reasonable

### DIFF
--- a/lib/DBI/DBD/SqlEngine.pm
+++ b/lib/DBI/DBD/SqlEngine.pm
@@ -816,7 +816,9 @@ sub new_sql_engine_meta
     }
 
     $dbh->{sql_meta}{$table} = { %{$values} };
-    ( my $class = $dbh->{ImplementorClass} ) =~ s/::db$/::Table/;
+    my $class;
+    defined $values->{sql_table_class} and $class = $values->{sql_table_class};
+    defined $class or ( $class = $dbh->{ImplementorClass} ) =~ s/::db$/::Table/;
     # XXX we should never hit DBD::File::Table::get_table_meta here ...
     my ( undef, $meta ) = $class->get_table_meta( $dbh, $table, $respect_case );
     1;

--- a/lib/DBI/DBD/SqlEngine.pm
+++ b/lib/DBI/DBD/SqlEngine.pm
@@ -1456,6 +1456,11 @@ sub open_table ($$$$$)
                 };
     $self->{command} eq "DROP" and $flags->{dropMode} = 1;
 
+    my ( $tblnm, $table_meta ) = $class->get_table_meta( $data->{Database}, $table, 1 )
+      or croak "Cannot find appropriate meta for table '$table'";
+
+    defined $table_meta->{sql_table_class} and $class = $table_meta->{sql_table_class};
+
     # because column name mapping is initialized in constructor ...
     # and therefore specific opening operations might be done before
     # reaching DBI::DBD::SqlEngine::Table->new(), we need to intercept
@@ -1463,8 +1468,6 @@ sub open_table ($$$$$)
     my $write_op = $createMode || $lockMode || $flags->{dropMode};
     if ($write_op)
     {
-        my ( $tblnm, $table_meta ) = $class->get_table_meta( $data->{Database}, $table, 1 )
-          or croak "Cannot find appropriate file for table '$table'";
         $table_meta->{readonly}
           and croak "Table '$table' is marked readonly - "
           . $self->{command}

--- a/t/53sqlengine_adv.t
+++ b/t/53sqlengine_adv.t
@@ -1,0 +1,49 @@
+#!perl -w
+$| = 1;
+
+use strict;
+use warnings;
+
+require DBD::DBM;
+
+use File::Path;
+use File::Spec;
+use Test::More;
+use Cwd;
+use Config qw(%Config);
+use Storable qw(dclone);
+
+my $using_dbd_gofer = ( $ENV{DBI_AUTOPROXY} || '' ) =~ /^dbi:Gofer.*transport=/i;
+plan skip_all => "Modifying driver state won't compute running behind Gofer" if($using_dbd_gofer);
+
+use DBI;
+
+# <[Sno]> what I could do is create a new test case where inserting into a DBD::DBM and after that clone the meta into a DBD::File $dbh
+# <[Sno]> would that help to get a better picture?
+
+do "t/lib.pl";
+my $dir = test_dir();
+
+my $dbm_dbh = DBI->connect( 'dbi:DBM:', undef, undef, {
+      f_dir               => $dir,
+      sql_identifier_case => 2,      # SQL_IC_LOWER
+    }
+);
+
+$dbm_dbh->do(q/create table FRED (a integer, b integer)/);
+$dbm_dbh->do(q/insert into fRED (a,b) values(1,2)/);
+$dbm_dbh->do(q/insert into FRED (a,b) values(2,1)/);
+
+my $f_dbh = DBI->connect( 'dbi:File:', undef, undef, {
+      f_dir               => $dir,
+      sql_identifier_case => 2,      # SQL_IC_LOWER
+    }
+);
+
+my $dbm_fred_meta = $dbm_dbh->f_get_meta("fred", [qw(dbm_type)]);
+$f_dbh->f_new_meta( "fred", {sql_table_class => "DBD::DBM::Table"} );
+
+my $r = $f_dbh->selectall_arrayref(q/select * from Fred/);
+ok( @$r == 2, 'rows found via mixed case table' );
+
+done_testing();


### PR DESCRIPTION
When SqlEngine requests opening a table or new meta info is created - care to choose right table class instead of guessing based on driver.

This patch openes the door for having a table dictionary in DBD::File (maybe DBI::DBD::SqlEngine, too - but how and where to store).

With it, a DBD::CSV $dbh could deal with a DBM based table in one query without temporary tables or anything.