### PR TITLE
Enable strictures on all lib/ files

### DIFF
--- a/lib/Bundle/DBI.pm
+++ b/lib/Bundle/DBI.pm
@@ -2,6 +2,7 @@
 
 package Bundle::DBI;
 
+use strict;
 our $VERSION = "12.008696";
 
 1;

--- a/lib/DBD/ExampleP.pm
+++ b/lib/DBD/ExampleP.pm
@@ -1,11 +1,15 @@
 {
     package DBD::ExampleP;
 
+    use strict;
     use Symbol;
 
     use DBI qw(:sql_types);
 
     require File::Spec;
+   
+    our (@EXPORT,$VERSION,@statnames,%statnames,@stattypes,%stattypes,
+	@statprec,%statprec,$drh,);
 
     @EXPORT = qw(); # Do NOT @EXPORT anything.
     $VERSION = "12.014311";

--- a/lib/DBD/Multiplex.pm
+++ b/lib/DBD/Multiplex.pm
@@ -18,6 +18,8 @@
 
 # some file-scoped lexicals:
 
+use strict;
+
 my %parent_only_attr = (
     # mx needs to manage errors from children
     RaiseError => 1, PrintError => 1, HandleError => 1,
@@ -287,7 +289,7 @@ sub mx_error_subroutine {
 { #================================================================ DRIVER ===
 
 package DBD::Multiplex::dr;
-    $imp_data_size = $imp_data_size = 0;
+    our $imp_data_size = $imp_data_size = 0;
     use strict;
 
 ########################################
@@ -447,7 +449,7 @@ sub disconnect_all { } # needed for DBI < ~1.35
 { #============================================================== DATABASE ===
 
 package DBD::Multiplex::db;
-	$imp_data_size = $imp_data_size = 0;
+	our $imp_data_size = $imp_data_size = 0;
 	use strict;
 
 ########################################
@@ -621,7 +623,7 @@ sub AUTOLOAD {
 { #============================================================= STATEMENT ===
 
 package DBD::Multiplex::st;
-$imp_data_size = $imp_data_size = 0;
+our $imp_data_size = $imp_data_size = 0;
 use strict;
 
 ########################################

--- a/lib/DBD/NullP.pm
+++ b/lib/DBD/NullP.pm
@@ -1,11 +1,12 @@
+use strict;
 {
     package DBD::NullP;
-
+    
     require DBI;
     require Carp;
 
-    @EXPORT = qw(); # Do NOT @EXPORT anything.
-    $VERSION = "12.014715";
+    our @EXPORT = qw(); # Do NOT @EXPORT anything.
+    our $VERSION = "12.014715";
 
 #   $Id: NullP.pm 14714 2011-02-22 17:27:07Z Tim $
 #
@@ -14,7 +15,7 @@
 #   You may distribute under the terms of either the GNU General Public
 #   License or the Artistic License, as specified in the Perl README file.
 
-    $drh = undef;	# holds driver handle once initialised
+    our $drh = undef;	# holds driver handle once initialised
 
     sub driver{
 	return $drh if $drh;
@@ -35,7 +36,7 @@
 
 
 {   package DBD::NullP::dr; # ====== DRIVER ======
-    $imp_data_size = 0;
+    our $imp_data_size = 0;
     use strict;
 
     sub connect { # normally overridden, but a handy default
@@ -51,7 +52,7 @@
 
 
 {   package DBD::NullP::db; # ====== DATABASE ======
-    $imp_data_size = 0;
+    our $imp_data_size = 0;
     use strict;
     use Carp qw(croak);
 
@@ -99,7 +100,7 @@
 
 
 {   package DBD::NullP::st; # ====== STATEMENT ======
-    $imp_data_size = 0;
+    our $imp_data_size = 0;
     use strict;
 
     sub bind_param {

--- a/lib/DBD/Sponge.pm
+++ b/lib/DBD/Sponge.pm
@@ -1,3 +1,4 @@
+use strict;
 {
     package DBD::Sponge;
 
@@ -14,7 +15,7 @@
 #   You may distribute under the terms of either the GNU General Public
 #   License or the Artistic License, as specified in the Perl README file.
 
-    $drh = undef;	# holds driver handle once initialised
+    our $drh = undef;	# holds driver handle once initialised
     my $methods_already_installed;
 
     sub driver{
@@ -40,13 +41,13 @@
 
 
 {   package DBD::Sponge::dr; # ====== DRIVER ======
-    $imp_data_size = 0;
+    our $imp_data_size = 0;
     # we use default (dummy) connect method
 }
 
 
 {   package DBD::Sponge::db; # ====== DATABASE ======
-    $imp_data_size = 0;
+    our $imp_data_size = 0;
     use strict;
 
     sub prepare {
@@ -156,7 +157,7 @@
 
 
 {   package DBD::Sponge::st; # ====== STATEMENT ======
-    $imp_data_size = 0;
+    our $imp_data_size = 0;
     use strict;
 
     sub execute {

--- a/lib/DBI/Const/GetInfo/ANSI.pm
+++ b/lib/DBI/Const/GetInfo/ANSI.pm
@@ -7,8 +7,11 @@
 #
 # You may distribute under the terms of either the GNU General Public
 # License or the Artistic License, as specified in the Perl README file.
+use strict;
 
 package DBI::Const::GetInfo::ANSI;
+
+our (%InfoTypes,%ReturnTypes,%ReturnValues,);
 
 =head1 NAME
 

--- a/lib/DBI/Const/GetInfo/ODBC.pm
+++ b/lib/DBI/Const/GetInfo/ODBC.pm
@@ -7,9 +7,10 @@
 #
 # You may distribute under the terms of either the GNU General Public
 # License or the Artistic License, as specified in the Perl README file.
-
+use strict;
 package DBI::Const::GetInfo::ODBC;
 
+our (%InfoTypes,%ReturnTypes,%ReturnValues,);
 =head1 NAME
 
 DBI::Const::GetInfo::ODBC - ODBC Constants for GetInfo

--- a/lib/DBI/DBD.pm
+++ b/lib/DBI/DBD.pm
@@ -1,6 +1,6 @@
 package DBI::DBD;
 # vim:ts=8:sw=4
-
+use strict;
 use vars qw($VERSION);	# set $VERSION early so we don't confuse PAUSE/CPAN etc
 
 # don't use Revision here because that's not in svn:keywords so that the

--- a/lib/DBI/DBD/Metadata.pm
+++ b/lib/DBI/DBD/Metadata.pm
@@ -8,19 +8,20 @@ package DBI::DBD::Metadata;
 # You may distribute under the terms of either the GNU General Public
 # License or the Artistic License, as specified in the Perl README file.
 
+use strict;
+
 use Exporter ();
 use Carp;
 
 use DBI;
 use DBI::Const::GetInfoType qw(%GetInfoType);
 
-# Perl 5.005_03 does not recognize 'our'
-@ISA = qw(Exporter);
-@EXPORT = qw(write_getinfo_pm write_typeinfo_pm);
+# Perl 5.005_03 does not recognize 'our' but perl 5.008 is minimun version
+our @ISA = qw(Exporter);
+our @EXPORT = qw(write_getinfo_pm write_typeinfo_pm);
 
-$VERSION = "2.014214";
+our $VERSION = "2.014214";
 
-use strict;
 
 =head1 NAME
 

--- a/lib/DBI/FAQ.pm
+++ b/lib/DBI/FAQ.pm
@@ -18,6 +18,7 @@
 ### commercial products, such as books, magazine articles or CD-ROMs should be
 ### made to Alligator Descartes.
 ###
+use strict;
 
 package DBI::FAQ;
 

--- a/lib/Win32/DBIODBC.pm
+++ b/lib/Win32/DBIODBC.pm
@@ -1,7 +1,7 @@
 package			# hide this package from CPAN indexer
 	Win32::ODBC;
 
-#use strict;
+use strict;
 
 use DBI;
 


### PR DESCRIPTION
This is part of my May CPAN pull request
 Adds "use strict" earlier on the files  where it was missing.
 predeclares the variables with our (..,); on most of the packages
 some of the pakages declare wiht our on the creation of the variable;

I did not change the variables declared with vars pragma
