### PR TITLE
Enabling warnings on all lib/* perl code files

### DIFF
--- a/lib/Bundle/DBI.pm
+++ b/lib/Bundle/DBI.pm
@@ -3,6 +3,7 @@
 package Bundle::DBI;
 
 use strict;
+use warnings;
 our $VERSION = "12.008696";
 
 1;

--- a/lib/DBD/DBM.pm
+++ b/lib/DBD/DBM.pm
@@ -18,6 +18,7 @@
 #######################################################################
 require 5.008;
 use strict;
+use warnings;
 
 #################
 package DBD::DBM;
@@ -61,7 +62,10 @@ sub CLONE
 #####################
 package DBD::DBM::dr;
 #####################
-$DBD::DBM::dr::imp_data_size = 0;
+{
+    no warnings qw(once);
+    $DBD::DBM::dr::imp_data_size = 0;
+}
 @DBD::DBM::dr::ISA           = qw(DBD::File::dr);
 
 # you could put some :dr private methods here
@@ -73,7 +77,10 @@ $DBD::DBM::dr::imp_data_size = 0;
 #####################
 package DBD::DBM::db;
 #####################
-$DBD::DBM::db::imp_data_size = 0;
+{
+    no warnings qw(once);
+    $DBD::DBM::db::imp_data_size = 0;
+}
 @DBD::DBM::db::ISA           = qw(DBD::File::db);
 
 use Carp qw/carp/;
@@ -207,7 +214,10 @@ sub get_dbm_versions
 #####################
 package DBD::DBM::st;
 #####################
-$DBD::DBM::st::imp_data_size = 0;
+{
+    no warnings qw(once);
+    $DBD::DBM::st::imp_data_size = 0;
+}
 @DBD::DBM::st::ISA           = qw(DBD::File::st);
 
 sub FETCH
@@ -386,6 +396,7 @@ sub open_data
 
         if ( $meta->{dbm_mldbm} )
         {
+            no warnings qw(once);
             $MLDBM::UseDB      = $meta->{dbm_usedb};
             $MLDBM::Serializer = $meta->{dbm_mldbm};
         }

--- a/lib/DBD/ExampleP.pm
+++ b/lib/DBD/ExampleP.pm
@@ -1,7 +1,9 @@
+use strict;
+use warnings;
+
 {
     package DBD::ExampleP;
 
-    use strict;
     use Symbol;
 
     use DBI qw(:sql_types);
@@ -59,8 +61,7 @@
 
 
 {   package DBD::ExampleP::dr; # ====== DRIVER ======
-    $imp_data_size = 0;
-    use strict;
+    our $imp_data_size = 0;
 
     sub connect { # normally overridden, but a handy default
         my($drh, $dbname, $user, $auth)= @_;
@@ -86,7 +87,7 @@
 
 
 {   package DBD::ExampleP::db; # ====== DATABASE ======
-    $imp_data_size = 0;
+    our $imp_data_size = 0;
     use strict;
 
     sub prepare {
@@ -297,8 +298,8 @@
 
 
 {   package DBD::ExampleP::st; # ====== STATEMENT ======
-    $imp_data_size = 0;
-    use strict; no strict 'refs'; # cause problems with filehandles
+    our $imp_data_size = 0;
+    no strict 'refs'; # cause problems with filehandles
 
     sub bind_param {
 	my($sth, $param, $value, $attribs) = @_;
@@ -385,7 +386,9 @@
 
 	return $sth->_set_fbav(\@new);
     }
+    no warnings qw(once);
     *fetchrow_arrayref = \&fetch;
+    use warnings qw(once);
 
 
     sub finish {
@@ -428,6 +431,7 @@
 	return $sth->SUPER::STORE($attrib, $value);
     }
 
+    no warnings qw(once);
     *parse_trace_flag = \&DBD::ExampleP::db::parse_trace_flag;
 }
 

--- a/lib/DBD/Gofer.pm
+++ b/lib/DBD/Gofer.pm
@@ -1,7 +1,8 @@
+use strict;
+use warnings;
+
 {
     package DBD::Gofer;
-
-    use strict;
 
     require DBI;
     require DBI::Gofer::Request;
@@ -137,8 +138,7 @@
 
 {   package DBD::Gofer::dr; # ====== DRIVER ======
 
-    $imp_data_size = 0;
-    use strict;
+    our $imp_data_size = 0;
 
     sub connect_cached {
         my ($drh, $dsn, $user, $auth, $attr)= @_;
@@ -264,8 +264,7 @@
 
 
 {   package DBD::Gofer::db; # ====== DATABASE ======
-    $imp_data_size = 0;
-    use strict;
+    our $imp_data_size = 0;
     use Carp qw(carp croak);
 
     my %dbh_local_store_attrib = %DBD::Gofer::xxh_local_store_attrib;
@@ -570,13 +569,13 @@
         }, $if_active);
     }
 
+    no warnings qw(once);
     *go_cache = \&DBD::Gofer::go_cache;
 }
 
 
 {   package DBD::Gofer::st; # ====== STATEMENT ======
-    $imp_data_size = 0;
-    use strict;
+    our $imp_data_size = 0;
 
     my %sth_local_store_attrib = (%DBD::Gofer::xxh_local_store_attrib, NUM_OF_FIELDS => 1);
 
@@ -740,8 +739,9 @@
         $sth->finish;     # no more data so finish
         return undef;
     }
+    no warnings qw(once);
     *fetch = \&fetchrow_arrayref; # alias
-
+    use warnings qw(once);
 
     sub fetchall_arrayref {
         my ($sth, $slice, $max_rows) = @_;
@@ -802,7 +802,7 @@
         push @{ $sth->{go_method_calls} }, [ 'execute_array', $attr ];
         return $sth->go_sth_method($attr);
     }
-
+    no warnings qw(once);
     *go_cache = \&DBD::Gofer::go_cache;
 }
 

--- a/lib/DBD/Multiplex/Logic/Default.pm
+++ b/lib/DBD/Multiplex/Logic/Default.pm
@@ -1,6 +1,8 @@
 package DBD::Multiplex::Logic::Default;
 
 use strict;
+use warnings;
+
 no strict 'refs';
 
 sub mx_pick_handles {

--- a/lib/DBD/NullP.pm
+++ b/lib/DBD/NullP.pm
@@ -1,4 +1,5 @@
 use strict;
+use warnings;
 {
     package DBD::NullP;
     
@@ -149,7 +150,9 @@ use strict;
 	}
         return $sth->_set_fbav(shift @$data);
     }
+    no warnings qw(once);
     *fetch = \&fetchrow_arrayref; # alias
+    use warnings qw(once);
 
     sub FETCH {
 	my ($sth, $attrib) = @_;

--- a/lib/DBD/Proxy.pm
+++ b/lib/DBD/Proxy.pm
@@ -21,6 +21,7 @@
 #
 
 use strict;
+use warnings;
 use Carp;
 
 require DBI;
@@ -91,7 +92,10 @@ sub proxy_set_err {
 
 package DBD::Proxy::dr; # ====== DRIVER ======
 
-$DBD::Proxy::dr::imp_data_size = 0;
+{
+    no warnings qw(once);
+    $DBD::Proxy::dr::imp_data_size = 0;
+}
 
 sub connect ($$;$$) {
     my($drh, $dsn, $user, $auth, $attr)= @_;
@@ -217,7 +221,10 @@ sub DESTROY { undef }
 
 package DBD::Proxy::db; # ====== DATABASE ======
 
-$DBD::Proxy::db::imp_data_size = 0;
+{
+    no warnings qw(once);
+    $DBD::Proxy::db::imp_data_size = 0;
+}
 
 # XXX probably many more methods need to be added here
 # in order to trigger our AUTOLOAD to redirect them to the server.
@@ -478,7 +485,10 @@ sub type_info_all {
 
 package DBD::Proxy::st; # ====== STATEMENT ======
 
-$DBD::Proxy::st::imp_data_size = 0;
+{
+    no warnings qw(once);
+    $DBD::Proxy::st::imp_data_size = 0;
+}
 
 use vars qw(%ATTR);
 
@@ -505,7 +515,9 @@ use vars qw(%ATTR);
     'NUM_OF_PARAMS' => 'cache_only'
 );
 
+no warnings qw(once);
 *AUTOLOAD = \&DBD::Proxy::db::AUTOLOAD;
+use warnings qw(once);
 
 sub execute ($@) {
     my $sth = shift;
@@ -622,7 +634,9 @@ sub fetch ($) {
     $sth->{'proxy_rows'}++;
     return $sth->_set_fbav($row);
 }
+no warnings qw(once);
 *fetchrow_arrayref = \&fetch;
+use warnings qw(once);
 
 sub rows ($) {
     my $rows = shift->{'proxy_rows'};
@@ -713,7 +727,10 @@ sub bind_param ($$$@) {
     my $sth = shift; my $param = shift;
     $sth->{'proxy_params'}->[$param-1] = [@_];
 }
+
+no warnings qw(once);
 *bind_param_inout = \&bind_param;
+use warnings qw(once);
 
 sub DESTROY {
     my $sth = shift;

--- a/lib/DBD/Sponge.pm
+++ b/lib/DBD/Sponge.pm
@@ -177,7 +177,7 @@ use warnings;
 	    my $NUM_OF_PARAMS = $sth->{NUM_OF_PARAMS};
 	    return $sth->set_err($DBI::stderr, @$row." values bound (@$row) but $NUM_OF_PARAMS expected")
 		if @$row != $NUM_OF_PARAMS;
-	    { local $^W; $sth->trace_msg("inserting (@$row)\n"); }
+	    { local $^W; no warnings qw(uninitialized); $sth->trace_msg("inserting (@$row)\n"); }
 	    push @{ $sth->{rows} }, $row;
 	}
 	else {	# mark select sth as Active

--- a/lib/DBD/Sponge.pm
+++ b/lib/DBD/Sponge.pm
@@ -1,4 +1,5 @@
 use strict;
+use warnings;
 {
     package DBD::Sponge;
 
@@ -195,7 +196,9 @@ use strict;
 	}
 	return $sth->_set_fbav($row);
     }
+    no warnings qw(once);
     *fetchrow_arrayref = \&fetch;
+    use warnings qw(once);
 
     sub FETCH {
 	my ($sth, $attrib) = @_;

--- a/lib/DBI/Const/GetInfo/ANSI.pm
+++ b/lib/DBI/Const/GetInfo/ANSI.pm
@@ -8,6 +8,7 @@
 # You may distribute under the terms of either the GNU General Public
 # License or the Artistic License, as specified in the Perl README file.
 use strict;
+use warnings;
 
 package DBI::Const::GetInfo::ANSI;
 

--- a/lib/DBI/Const/GetInfo/ODBC.pm
+++ b/lib/DBI/Const/GetInfo/ODBC.pm
@@ -8,6 +8,8 @@
 # You may distribute under the terms of either the GNU General Public
 # License or the Artistic License, as specified in the Perl README file.
 use strict;
+use warnings;
+
 package DBI::Const::GetInfo::ODBC;
 
 our (%InfoTypes,%ReturnTypes,%ReturnValues,);

--- a/lib/DBI/Const/GetInfoReturn.pm
+++ b/lib/DBI/Const/GetInfoReturn.pm
@@ -10,6 +10,7 @@
 package DBI::Const::GetInfoReturn;
 
 use strict;
+use warnings;
 
 use Exporter ();
 

--- a/lib/DBI/Const/GetInfoType.pm
+++ b/lib/DBI/Const/GetInfoType.pm
@@ -10,6 +10,7 @@
 package DBI::Const::GetInfoType;
 
 use strict;
+use warnings;
 
 use Exporter ();
 

--- a/lib/DBI/DBD.pm
+++ b/lib/DBI/DBD.pm
@@ -1,6 +1,8 @@
 package DBI::DBD;
 # vim:ts=8:sw=4
 use strict;
+use warnings;
+
 use vars qw($VERSION);	# set $VERSION early so we don't confuse PAUSE/CPAN etc
 
 # don't use Revision here because that's not in svn:keywords so that the

--- a/lib/DBI/DBD/Metadata.pm
+++ b/lib/DBI/DBD/Metadata.pm
@@ -9,6 +9,7 @@ package DBI::DBD::Metadata;
 # License or the Artistic License, as specified in the Perl README file.
 
 use strict;
+use warnings;
 
 use Exporter ();
 use Carp;

--- a/lib/DBI/DBD/SqlEngine.pm
+++ b/lib/DBI/DBD/SqlEngine.pm
@@ -22,6 +22,7 @@
 require 5.008;
 
 use strict;
+use warnings;
 
 use DBI ();
 require DBI::SQL::Nano;

--- a/lib/DBI/FAQ.pm
+++ b/lib/DBI/FAQ.pm
@@ -19,6 +19,7 @@
 ### made to Alligator Descartes.
 ###
 use strict;
+use warnings;
 
 package DBI::FAQ;
 

--- a/lib/DBI/Gofer/Request.pm
+++ b/lib/DBI/Gofer/Request.pm
@@ -8,6 +8,7 @@ package DBI::Gofer::Request;
 #   License or the Artistic License, as specified in the Perl README file.
 
 use strict;
+use warnings;
 
 use DBI qw(neat neat_list);
 

--- a/lib/DBI/Gofer/Response.pm
+++ b/lib/DBI/Gofer/Response.pm
@@ -8,6 +8,7 @@ package DBI::Gofer::Response;
 #   License or the Artistic License, as specified in the Perl README file.
 
 use strict;
+use warnings;
 
 use Carp;
 use DBI qw(neat neat_list);

--- a/lib/DBI/Profile.pm
+++ b/lib/DBI/Profile.pm
@@ -674,6 +674,7 @@ many forward references.  (Patches welcome!)
 
 
 use strict;
+use warnings;
 use vars qw(@ISA @EXPORT @EXPORT_OK $VERSION);
 use Exporter ();
 use UNIVERSAL ();

--- a/lib/DBI/ProfileData.pm
+++ b/lib/DBI/ProfileData.pm
@@ -1,5 +1,6 @@
 package DBI::ProfileData;
 use strict;
+use warnings;
 
 =head1 NAME
 

--- a/lib/DBI/ProfileDumper.pm
+++ b/lib/DBI/ProfileDumper.pm
@@ -1,5 +1,6 @@
 package DBI::ProfileDumper;
 use strict;
+use warnings;
 
 =head1 NAME
 

--- a/lib/DBI/ProfileDumper/Apache.pm
+++ b/lib/DBI/ProfileDumper/Apache.pm
@@ -1,6 +1,7 @@
 package DBI::ProfileDumper::Apache;
 
 use strict;
+use warnings;
 
 =head1 NAME
 

--- a/lib/DBI/ProxyServer.pm
+++ b/lib/DBI/ProxyServer.pm
@@ -24,6 +24,7 @@
 
 require 5.004;
 use strict;
+use warnings;
 
 use RPC::PlServer 0.2001;
 require DBI;

--- a/lib/DBI/ProxyServer.pm
+++ b/lib/DBI/ProxyServer.pm
@@ -99,7 +99,7 @@ my %DEFAULT_SERVER_OPTIONS;
 	    'finish' => 1
 	    }
     };
-    if ($Config::Config{'usethreads'} eq 'define') {
+    if (defined($Config::Config{'usethreads'}) and $Config::Config{'usethreads'} eq 'define') {
 	$o->{'mode'} = 'threads';
     } elsif ($Config::Config{'d_fork'} eq 'define') {
 	$o->{'mode'} = 'fork';
@@ -216,7 +216,7 @@ sub CallMethod {
     # $dbh. However, we'd have a reference loop in that case and
     # I would be concerned about garbage collection. :-(
     $dbh->{'private_server'} = $server;
-    $server->Debug("CallMethod: => " . do { local $^W; join(",", @_)});
+    $server->Debug("CallMethod: => " . do { local $^W; no warnings qw(uninitialized); join(",", @_)});
     my @result = eval { $server->SUPER::CallMethod(@_) };
     my $msg = $@;
     undef $dbh->{'private_server'};

--- a/lib/DBI/PurePerl.pm
+++ b/lib/DBI/PurePerl.pm
@@ -493,6 +493,7 @@ sub _setup_handle {
     my $h_inner = tied(%$h) || $h;
     if (($DBI::dbi_debug & 0xF) >= 4) {
 	local $^W;
+	no warnings qw(uninitialized); 
 	print $DBI::tfh "      _setup_handle(@_)\n";
     }
     $h_inner->{"imp_data"} = $imp_data;

--- a/lib/DBI/PurePerl.pm
+++ b/lib/DBI/PurePerl.pm
@@ -17,6 +17,7 @@ package		# hide from PAUSE
 ########################################################################
 
 use strict;
+use warnings;
 use Carp;
 require Symbol;
 
@@ -27,7 +28,9 @@ require utf8;
     return !(length($_[0]) == bytes::length($_[0]))
 } unless defined &utf8::is_utf8;
 
+no warnings qw(once);
 $DBI::PurePerl = $ENV{DBI_PUREPERL} || 1;
+use warnings qw(once);
 $DBI::PurePerl::VERSION = "2.014286";
 
 $DBI::neat_maxlen ||= 400;
@@ -798,6 +801,7 @@ sub swap_inner_handle {
     my ($h1, $h2) = @_;
     # can't make this work till we can get the outer handle from the inner one
     # probably via a WeakRef
+    no warnings qw(once);
     return $h1->set_err($DBI::stderr, "swap_inner_handle not currently supported by DBI::PurePerl");
 }
 
@@ -984,7 +988,9 @@ sub take_imp_data {
     delete $dbh->{$_} for (keys %is_valid_attribute);
     delete $dbh->{$_} for grep { m/^dbi_/ } keys %$dbh;
     # warn "@{[ %$dbh ]}";
+    no warnings qw(once);
     local $Storable::forgive_me = 1; # in case there are some CODE refs
+    use warnings qw(once);
     my $imp_data = Storable::freeze($dbh);
     # XXX um, should probably untie here - need to check dispatch behaviour
     return $imp_data;

--- a/lib/DBI/Util/_accessor.pm
+++ b/lib/DBI/Util/_accessor.pm
@@ -1,5 +1,6 @@
 package DBI::Util::_accessor;
 use strict;
+use warnings;
 use Carp;
 our $VERSION = "0.009479";
 

--- a/lib/DBI/W32ODBC.pm
+++ b/lib/DBI/W32ODBC.pm
@@ -53,6 +53,7 @@ use Win32::ODBC;
 @ISA = qw(Win32::ODBC);
 
 use strict;
+use warnings;
 
 $DBI::dbi_debug = $ENV{PERL_DBI_DEBUG} || 0;
 carp "Loaded (W32ODBC) DBI.pm ${'DBI::VERSION'} (debug $DBI::dbi_debug)"

--- a/lib/Win32/DBIODBC.pm
+++ b/lib/Win32/DBIODBC.pm
@@ -2,6 +2,7 @@ package			# hide this package from CPAN indexer
 	Win32::ODBC;
 
 use strict;
+use warnings;
 
 use DBI;
 


### PR DESCRIPTION
This is part of my CPAN Pull request challenge.

After enabling warnings I  cleaned compile time warnings using lexical scoped  "no warnings qw(once);"
when possible or pairs (no,use) around the offending code.

After that I cleaned the warnings emitted during make test, all where undefined warnings, using a "defined ...  and ..." on Boolean expressions or "no  warnings qw(undefined);" where appropriate as all of them where on the last exresion of a block