### PR TITLE
removed broken links from POD

### DIFF
--- a/DBI.pm
+++ b/DBI.pm
@@ -7531,7 +7531,7 @@ Unfortunately, this solution is somewhat messy, and it does I<not> work with
 perl versions less than perl 5.8 where C<POSIX::sigaction()> appears to be broken.
 
 For a cleaner implementation that works across perl versions, see Lincoln Baxter's
-Sys::SigAction module at L<http://search.cpan.org/~lbaxter/Sys-SigAction/>.
+Sys::SigAction module at L<Sys::SigAction>.
 The documentation for Sys::SigAction includes an longer discussion
 of this problem, and a DBD::Oracle test script.
 
@@ -8129,13 +8129,6 @@ A BNF syntax for SQL3 is available here:
 
   http://www.sqlstandards.org/SC32/WG3/Progression_Documents/Informal_working_drafts/iso-9075-2-1999.bnf
 
-The following links provide further useful information about SQL.
-Some of these are rather dated now but may still be useful.
-
-  http://www.jcc.com/SQLPages/jccs_sql.htm
-  http://www.contrib.andrew.cmu.edu/~shadow/sql.html
-  http://www.altavista.com/query?q=sql+tutorial
-
 
 =head2 Books and Articles
 
@@ -8154,9 +8147,9 @@ Details of many other books related to perl can be found at L<http://books.perl.
 
 Index of DBI related modules available from CPAN:
 
- https://metacpan.org/search?q=DBD%3A%3A
- https://metacpan.org/search?q=DBIx%3A%3A
- https://metacpan.org/search?q=DBI
+ L<https://metacpan.org/search?q=DBD%3A%3A>
+ L<https://metacpan.org/search?q=DBIx%3A%3A>
+ L<https://metacpan.org/search?q=DBI>
 
 For a good comparison of RDBMS-OO mappers and some OO-RDBMS mappers
 (including Class::DBI, Alzabo, and DBIx::RecordSet in the former
@@ -8174,7 +8167,7 @@ A similar page for Java toolkits can be found at:
 The I<dbi-users> mailing list is the primary means of communication among
 users of the DBI and its related modules. For details send email to:
 
- dbi-users-help@perl.org
+ L<dbi-users-help@perl.org>
 
 There are typically between 700 and 900 messages per month.  You have
 to subscribe in order to be able to post. However you can opt for a
@@ -8186,7 +8179,7 @@ Mailing list archives (of variable quality) are held at:
  http://www.xray.mpe.mpg.de/mailing-lists/dbi/
  http://www.mail-archive.com/dbi-users%40perl.org/
 
-=head2 Assorted Related WWW Links
+=head2 Assorted Related Links
 
 The DBI "Home Page":
 
@@ -8194,42 +8187,17 @@ The DBI "Home Page":
 
 Other DBI related links:
 
- http://tegan.deltanet.com/~phlip/DBUIdoc.html
- http://dc.pm.org/perl_db.html
- http://wdvl.com/Authoring/DB/Intro/toc.html
- http://www.hotwired.com/webmonkey/backend/tutorials/tutorial1.html
- http://bumppo.net/lists/macperl/1999/06/msg00197.html
  http://www.perlmonks.org/?node=DBI%20recipes
  http://www.perlmonks.org/?node=Speeding%20up%20the%20DBI
 
 Other database related links:
 
- http://www.jcc.com/sql_stnd.html
- http://cuiwww.unige.ch/OSG/info/FreeDB/FreeDB.home.html
  http://www.connectionstrings.com/
 
 Security, especially the "SQL Injection" attack:
 
- http://www.ngssoftware.com/research/papers.html
- http://www.ngssoftware.com/papers/advanced_sql_injection.pdf
- http://www.ngssoftware.com/papers/more_advanced_sql_injection.pdf
- http://www.esecurityplanet.com/trends/article.php/2243461
- http://www.spidynamics.com/papers/SQLInjectionWhitePaper.pdf
- http://www.imperva.com/application_defense_center/white_papers/blind_sql_server_injection.html
+ http://bobby-tables.com/
  http://online.securityfocus.com/infocus/1644
-
-Commercial and Data Warehouse Links
-
- http://www.dwinfocenter.org
- http://www.datawarehouse.com
- http://www.datamining.org
- http://www.olapcouncil.org
- http://www.idwa.org
- http://www.knowledgecenters.org/dwcenter.asp
-
-Recommended Perl Programming Links
-
- http://language.perl.com/style/
 
 
 =head2 FAQ
@@ -8404,11 +8372,6 @@ available, thanks to O'Reilly, at:
 
   http://www.oreilly.de/catalog/perldbiger/
 
-Some other translations:
-
- http://cronopio.net/perl/                              - Spanish
- http://member.nifty.ne.jp/hippo2000/dbimemo.htm        - Japanese
-
 =head1 TRAINING
 
 References to DBI related training resources. No recommendation implied.
@@ -8423,7 +8386,7 @@ please send me your details so I can add them here.)
 
 =over 4
 
-=item Apache::DBI by E.Mergl@bawue.de
+=item L<Apache::DBI>
 
 To be used with the Apache daemon together with an embedded Perl
 interpreter like C<mod_perl>. Establishes a database connection which


### PR DESCRIPTION
Many of the links in the DBI POD were dead, some lead to malware or
spam websites. I tried to remove them where needed.

By the way, many of the links in DBI::FAQ are also broken. This POD describes it is out of date and points to a document that does not seem to exist as a replacement. I'd suggest to remove the whole DBI::FAQ as it is really very old and it seems to be covered more up-to-date in the DBI pod anyway.