### PR TITLE
add appveyor: CI for Windows, like Travis

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: 1.0.{build}
+
+install:
+  - cinst StrawberryPerl
+  - path C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - mkdir %APPVEYOR_BUILD_FOLDER%\tmp
+  - set TMPDIR=%APPVEYOR_BUILD_FOLDER%\tmp
+  - perl -V
+  - cpan App::cpanminus
+  - cpanm -q --showdeps --with-develop --with-suggests . | findstr /v "^perl\>" | cpanm -n
+  - 'echo End install at: & time /t'
+
+build_script:
+  - perl Makefile.PL
+
+test_script:
+  - dmake test


### PR DESCRIPTION
Recently I found out about appveyor which is like Travis, but builds on Windows. It is very helpful especially for developers who don't have easy access to Windows.

Attached is a configuration for appveyor; you'll have to sign in there and register the perl5-dbi/dbi module yourself to enable builds. An example of a build is here: https://ci.appveyor.com/project/mbeijen/dbi/build/1.0.2

They have status badges just like Travis as well :-) 
http://www.appveyor.com/docs/status-badges