### PR TITLE
Fix fetchall_arrayref({}) behavior with no columns

### DIFF
--- a/DBI.pm
+++ b/DBI.pm
@@ -2080,7 +2080,10 @@ sub _new_sth {	# called by DBD::<drivername>::db::prepare)
                 }
 	    }
 	    else {
-		$sth->bind_columns( \( @row{ @{$sth->FETCH($sth->FETCH('FetchHashKeyName')) } } ) );
+		my @column_names = @{ $sth->FETCH($sth->FETCH('FetchHashKeyName')) };
+		return [] if !@column_names;
+
+		$sth->bind_columns( \( @row{@column_names} ) );
 	    }
 	}
 	else {


### PR DESCRIPTION
When no columns were present in a result set, `fetchall_arrayref({})` died
because the resulting arguments to `bind_columns` were incorrect (by
virtue of not existing at all). Since there can't be results with an
empty column set, this fixes the issue by returning an empty result set
in that case.

This issue was first referenced in November 2012:
http://www.nntp.perl.org/group/perl.dbi.users/2012/11/msg36513.html