### PR TITLE
Fix gofer.t test failures due to utf8-enabled STDIN/STDOUT

### DIFF
--- a/lib/DBI/Gofer/Transport/pipeone.pm
+++ b/lib/DBI/Gofer/Transport/pipeone.pm
@@ -22,6 +22,9 @@ my $executor = DBI::Gofer::Execute->new();
 
 sub run_one_stdio {
 
+    binmode STDIN;
+    binmode STDOUT;
+
     my $transport = DBI::Gofer::Transport::pipeone->new();
 
     my $frozen_request = do { local $/; <STDIN> };


### PR DESCRIPTION
To reproduce the failures, run `PERL_UNICODE=S make test`.