### PR TITLE
Fix crashing when calling warn() and croak() functions

### DIFF
--- a/DBI.xs
+++ b/DBI.xs
@@ -85,10 +85,10 @@ extern Pid_t getpid (void);
 #endif
 
 #ifndef warn_sv
-static void warn_sv(SV *sv) { dTHX; warn(SvPV_nolen(sv)); }
+static void warn_sv(SV *sv) { dTHX; warn("%s", SvPV_nolen(sv)); }
 #endif
 #ifndef croak_sv
-static void croak_sv(SV *sv) { dTHX; croak(SvPV_nolen(sv)); }
+static void croak_sv(SV *sv) { dTHX; croak("%s", SvPV_nolen(sv)); }
 #endif
 
 /* types of method name */
@@ -494,7 +494,7 @@ _join_hash_sorted(HV *hash, char *kv_sep, STRLEN kv_sep_len, char *pair_sep, STR
 
 /* handy for embedding into condition expression for debugging */
 /*
-static int warn1(char *s) { warn(s); return 1; }
+static int warn1(char *s) { warn("%s", s); return 1; }
 static int dump1(SV *sv)  { dTHX; sv_dump(sv); return 1; }
 */
 

--- a/dbipport.h
+++ b/dbipport.h
@@ -4794,7 +4794,7 @@ DPPP_(my_eval_pv)(char *p, I32 croak_on_error)
     PUTBACK;
 
     if (croak_on_error && SvTRUE(GvSV(errgv)))
-        croak(SvPVx(GvSV(errgv), na));
+        croak("%s", SvPVx(GvSV(errgv), na));
 
     return sv;
 }


### PR DESCRIPTION
Functions warn() and croak() take first parameter printf-like format.
Arbitrary string can cause perl crash when contains one or more '%'.

Format "%s" should be used to pass abitrary string parameter.