### PR TITLE
Fix disappearing $_ inside callbacks.

### DIFF
--- a/DBI.xs
+++ b/DBI.xs
@@ -3571,6 +3571,7 @@ XS(XS_DBI_dispatch)
         && SvROK(*hook_svp)
     ) {
         SV *orig_defsv;
+        SV *temp_defsv;
         SV *code = SvRV(*hook_svp);
         I32 skip_dispatch = 0;
         if (trace_level)
@@ -3587,7 +3588,11 @@ XS(XS_DBI_dispatch)
          */
         orig_defsv = DEFSV; /* remember the current $_ */
         SAVE_DEFSV;         /* local($_) = $method_name */
-        DEFSV_set(sv_2mortal(newSVpv(meth_name,0)));
+        temp_defsv = sv_2mortal(newSVpv(meth_name,0));
+# ifdef SvTEMP_off
+        SvTEMP_off(temp_defsv);
+# endif
+        DEFSV_set(temp_defsv);
 
         EXTEND(SP, items+1);
         PUSHMARK(SP);

--- a/t/70callbacks.t
+++ b/t/70callbacks.t
@@ -27,7 +27,9 @@ is $dbh->{Callbacks}, undef, "Callbacks set to undef again";
 
 ok $dbh->{Callbacks} = {
     ping => sub {
-	is $_, 'ping', '$_ holds method name';
+	my $m = $_;
+	is $m, 'ping', '$m holds method name';
+	is $_, 'ping', '$_ holds method name (not stolen)';
 	is @_, 1, '@_ holds 1 values';
 	is ref $_[0], 'DBI::db', 'first is $dbh';
         ok tied(%{$_[0]}), '$dbh is tied (outer) handle'


### PR DESCRIPTION
Hello,

I ran into a bug with callbacks where assigning $_ to another variable causes it to become undef, preventing the method from executing. I've added a test case to t/70callbacks.t in this pull request that illustrates the problem.

This happens because sv_2mortal sets the SvTEMP flag on the new defsv, enabling another variable to "steal" its string buffer (rather than make a copy, since the original is normally about to be discarded anyway).

This patch switches off the SvTEMP flag on the new sv after mortalizing it. This doesn't introduce a memory leak because it still exists on the temps stack, and it prevents the buffer theft.

List::Util had a similar issue and dealt with it in the same manner:

[1] https://rt.cpan.org/Public/Bug/Display.html?id=96343

[2] https://github.com/Dual-Life/Scalar-List-Utils/commit/1bddb84616f6ced1a74e13312dc57461a2655f14

[3] https://github.com/Dual-Life/Scalar-List-Utils/commit/0925609219490c2b37e906e089166ff125caf4e8

Thanks!
