### PR TITLE
Implement warn_sv/croak_sv with UTF-8 support also for Perl prior to 5.14

### DIFF
--- a/DBI.xs
+++ b/DBI.xs
@@ -85,10 +85,10 @@ extern Pid_t getpid (void);
 #endif
 
 #ifndef warn_sv
-static void warn_sv(SV *sv) { dTHX; warn("%s", SvPV_nolen(sv)); }
+static void warn_sv(SV *sv) { dTHX; warn("%" SVf, SVfARG(sv)); }
 #endif
 #ifndef croak_sv
-static void croak_sv(SV *sv) { dTHX; croak("%s", SvPV_nolen(sv)); }
+static void croak_sv(SV *sv) { dTHX; sv_setsv(ERRSV, sv); croak(NULL); }
 #endif
 
 /* types of method name */

--- a/t/91_store_warning.t
+++ b/t/91_store_warning.t
@@ -30,11 +30,8 @@ like $warning, qr/^DBD::\w+::db set_err warning: warning plain/, "Warning record
 $dbh->set_err(undef, undef);
 undef $warning;
 
-SKIP: {
-    skip "Perl version $] too old for unicode test", 2 unless $] >= 5.014;
-    $dbh->set_err("0", "warning \N{U+263A} smiley face");
-    like $warning, qr/^DBD::\w+::db set_err warning: warning \N{U+263A} smiley face/, "Warning recorded by store"
-        or warn DBI::data_string_desc($warning);
-}
+$dbh->set_err("0", "warning \N{U+263A} smiley face");
+like $warning, qr/^DBD::\w+::db set_err warning: warning \N{U+263A} smiley face/, "Warning recorded by store"
+    or warn DBI::data_string_desc($warning);
 
 done_testing;


### PR DESCRIPTION
Calling croak(NULL) would take exception from the $@ without loosing
SVf_UTF8 flag with a bonus which support object references. So it is better
equivalent for croak_sv() from Perl 5.14+.

Calling warn("%" SVf, SVfARG(sv)) is what older Perl's pp_warn() does to
pass scalar independently of SVf_UTF8 flag.

Fixes RT#102404 for Perl prior to 5.14.