### PR TITLE
Add mariadb_ prefix for a new DBD::MariaDB driver

### DIFF
--- a/DBI.pm
+++ b/DBI.pm
@@ -338,6 +338,7 @@ my $dbd_prefix_registry = {
   ing_         => { class => 'DBD::Ingres',         },
   ix_          => { class => 'DBD::Informix',       },
   jdbc_        => { class => 'DBD::JDBC',           },
+  mariadb_     => { class => 'DBD::MariaDB',        },
   mem_         => { class => 'DBD::Mem',            },
   mo_          => { class => 'DBD::MO',             },
   monetdb_     => { class => 'DBD::monetdb',        },


### PR DESCRIPTION
A new DBD::MariaDB driver is a fork of DBD::mysql and is currently
developed at github: https://github.com/gooddata/DBD-MariaDB

Without registering DBI prefix, DBD::MariaDB itself cannot register own
methods on $dbh or $sth handles and throw error:

method name prefix 'mariadb_' is not associated with a registered driver