### PR TITLE
Fix test t/91_store_warning.t

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,8 @@ perl:
   - "5.14"
   - "5.12"
   - "5.10"
+  - "5.10.0"
   - "5.8"
+  - "5.8.1"
+before_install:
+  - if [ -z "$PERLBREW_PERL" ]; then eval $(curl https://travis-perl.github.io/init) --auto; fi

--- a/t/91_store_warning.t
+++ b/t/91_store_warning.t
@@ -31,7 +31,7 @@ $dbh->set_err(undef, undef);
 undef $warning;
 
 $dbh->set_err("0", "warning \N{U+263A} smiley face");
-like $warning, qr/^DBD::\w+::db set_err warning: warning \N{U+263A} smiley face/, "Warning recorded by store"
+like $warning, qr/^DBD::\w+::db set_err warning: warning \x{263A} smiley face/, "Warning recorded by store"
     or warn DBI::data_string_desc($warning);
 
 done_testing;


### PR DESCRIPTION
Use \x{263A} syntax instead of \N{U+263A} in qr//. It looks like \N does not work in qr// with Perl 5.10.0.