### PR TITLE
Fix compile warnings in Driver.xst

### DIFF
--- a/Driver.xst
+++ b/Driver.xst
@@ -122,6 +122,7 @@ _login(dbh, dbname, username, password, attribs=Nullsv)
 #elif defined(dbd_db_login6)
     ST(0) = dbd_db_login6(dbh, imp_dbh, SvPV_nolen(dbname), u, p, attribs) ? &PL_sv_yes : &PL_sv_no;
 #else
+    PERL_UNUSED_ARG(attribs);
     ST(0) = dbd_db_login( dbh, imp_dbh, SvPV_nolen(dbname), u, p) ? &PL_sv_yes : &PL_sv_no;
 #endif
     }

--- a/Perl.xs
+++ b/Perl.xs
@@ -26,10 +26,10 @@ struct imp_sth_st {
 
 
 #define dbd_discon_all(drh, imp_drh)            (drh=drh,imp_drh=imp_drh,1)
-#define dbd_dr_data_sources(drh, imp_drh, attr) (drh=drh,imp_drh=imp_drh,Nullav)
+#define dbd_dr_data_sources(drh, imp_drh, attr) (drh=drh,imp_drh=imp_drh,attr=attr,Nullav)
 #define dbd_db_do4_iv(dbh,imp_dbh,p3,p4)        (dbh=dbh,imp_dbh=imp_dbh,p3=p3,p4=p4,-2)
 #define dbd_db_last_insert_id(dbh, imp_dbh, p3,p4,p5,p6, attr) \
-        (dbh=dbh,imp_dbh=imp_dbh,p3=p3,p4=p4,p5=p5,p6=p6,&PL_sv_undef)
+        (dbh=dbh,imp_dbh=imp_dbh,p3=p3,p4=p4,p5=p5,p6=p6,attr=attr,&PL_sv_undef)
 #define dbd_take_imp_data(h, imp_xxh, p3)       (h=h,imp_xxh=imp_xxh,&PL_sv_undef)
 #define dbd_st_execute_for_fetch(sth, imp_sth, p3, p4) \
         (sth=sth,imp_sth=imp_sth,p3=p3,p4=p4,&PL_sv_undef)


### PR DESCRIPTION
Perl.c: In function ‘XS_DBD__Perl__dr_data_sources’:
Perl.c:276:7: warning: variable ‘attr’ set but not used [-Wunused-but-set-variable]
  SV * attr;
       ^~~~
Perl.c: In function ‘XS_DBD__Perl__db__login’:
Perl.c:320:7: warning: variable ‘attribs’ set but not used [-Wunused-but-set-variable]
  SV * attribs;
       ^~~~~~~
Perl.c: In function ‘XS_DBD__Perl__db_last_insert_id’:
Perl.c:604:7: warning: variable ‘attr’ set but not used [-Wunused-but-set-variable]
  SV * attr;
       ^~~~