### PR TITLE
Add a new API function dbd_db_do6()

### DIFF
--- a/Driver.xst
+++ b/Driver.xst
@@ -251,19 +251,27 @@ selectrow_arrayref(...)
 #endif
 
 
-#ifdef dbd_db_do4 /* deebeedee-deebee-doo, deebee-doobee-dah? */
+#if defined(dbd_db_do6) || defined(dbd_db_do4)
 
 void
-do(dbh, statement, params = Nullsv)
+do(dbh, statement, params = Nullsv, ...)
     SV *        dbh
-    char *      statement
+    SV *        statement
     SV *        params
     CODE:
     {
     D_imp_dbh(dbh);
     IV retval;
-    retval = dbd_db_do4(dbh, imp_dbh, statement, params); /* might be dbd_db_do4_iv via macro */
-    /* remember that dbd_db_do4 must return <= -2 for error     */
+#ifdef dbd_db_do6
+    /* items is a number of arguments passed to XSUB, supplied by xsubpp compiler */
+    /* ax contains stack base offset used by ST() macro, supplied by xsubpp compiler */
+    retval = dbd_db_do6(dbh, imp_dbh, statement, params, items-3, ax+3);
+#else
+    if (items > 3)
+        croak_xs_usage(cv,  "dbh, statement, params = Nullsv");
+    retval = dbd_db_do4(dbh, imp_dbh, SvPV_nolen(statement), params); /* might be dbd_db_do4_iv via macro */
+#endif
+    /* remember that dbd_db_do* must return <= -2 for error     */
     if (retval == 0)            /* ok with no rows affected     */
         XST_mPV(0, "0E0");      /* (true but zero)              */
     else if (retval < -1)       /* -1 == unknown number of rows */

--- a/Perl.xs
+++ b/Perl.xs
@@ -27,7 +27,7 @@ struct imp_sth_st {
 
 #define dbd_discon_all(drh, imp_drh)            (drh=drh,imp_drh=imp_drh,1)
 #define dbd_dr_data_sources(drh, imp_drh, attr) (drh=drh,imp_drh=imp_drh,attr=attr,Nullav)
-#define dbd_db_do4_iv(dbh,imp_dbh,p3,p4)        (dbh=dbh,imp_dbh=imp_dbh,p3=p3,p4=p4,-2)
+#define dbd_db_do4_iv(dbh,imp_dbh,p3,p4)        (dbh=dbh,imp_dbh=imp_dbh,(void*)p3,p4=p4,-2)
 #define dbd_db_last_insert_id(dbh, imp_dbh, p3,p4,p5,p6, attr) \
         (dbh=dbh,imp_dbh=imp_dbh,p3=p3,p4=p4,p5=p5,p6=p6,attr=attr,&PL_sv_undef)
 #define dbd_take_imp_data(h, imp_xxh, p3)       (h=h,imp_xxh=imp_xxh,&PL_sv_undef)

--- a/dbd_xsh.h
+++ b/dbd_xsh.h
@@ -27,8 +27,9 @@ int      dbd_db_login  _((SV *dbh, imp_dbh_t *imp_dbh, char *dbname, char *uid, 
 /* Note: interface of dbd_db_do changed in v1.33 */
 /* Old prototype: dbd_db_do _((SV *sv, char *statement)); */
 /* dbd_db_do: optional: defined by a driver if the DBI default version is too slow */
-int      dbd_db_do4    _((SV *dbh, imp_dbh_t *imp_dbh, char *statement, SV *params));
-IV       dbd_db_do4_iv _((SV *dbh, imp_dbh_t *imp_dbh, char *statement, SV *params));
+int      dbd_db_do4    _((SV *dbh, imp_dbh_t *imp_dbh, char *statement, SV *params)); /* deprecated */
+IV       dbd_db_do4_iv _((SV *dbh, imp_dbh_t *imp_dbh, char *statement, SV *params)); /* deprecated */
+IV       dbd_db_do6    _((SV *dbh, imp_dbh_t *imp_dbh, SV *statement, SV *params, I32 items, I32 ax));
 int      dbd_db_commit     _((SV *dbh, imp_dbh_t *imp_dbh));
 int      dbd_db_rollback   _((SV *dbh, imp_dbh_t *imp_dbh));
 int      dbd_db_disconnect _((SV *dbh, imp_dbh_t *imp_dbh));


### PR DESCRIPTION
`dbd_db_do6()`:
* fixes `dbd_db_do4()` design as it is affected by **The Unicode bug**
* allows DBI drivers to implement `$dbh->do()` method with bind parameters