### PR TITLE
Fix compile warning dbipport.h:4471:0: warning: "WIDEST_UTYPE" redefined

### DIFF
--- a/dbipport.h
+++ b/dbipport.h
@@ -4466,15 +4466,18 @@ typedef OP* (CPERLscope(*Perl_check_t)) (pTHX_ OP*);
 #  undef isPRINT
 # endif
 
-#ifdef HAS_QUAD
-# ifdef U64TYPE
-#  define WIDEST_UTYPE U64TYPE
+#ifndef WIDEST_UTYPE
+# ifdef QUADKIND
+#  ifdef U64TYPE
+#   define WIDEST_UTYPE U64TYPE
+#  else
+#   define WIDEST_UTYPE Quad_t
+#  endif
 # else
-#  define WIDEST_UTYPE Quad_t
+#  define WIDEST_UTYPE U32
 # endif
-#else
-# define WIDEST_UTYPE U32
 #endif
+
 #ifndef isALNUMC
 #  define isALNUMC(c)                    (isALPHA(c) || isDIGIT(c))
 #endif


### PR DESCRIPTION
Copy WIDEST_UTYPE implementation from upstream fix:
https://perl5.git.perl.org/perl.git/commit/111bb90039d365ca2fbdae1ed5c1b03c4c37637a