### PR TITLE
Fix calling newSV() in malloc_using_sv()

### DIFF
--- a/DBI.xs
+++ b/DBI.xs
@@ -308,7 +308,7 @@ static void *
 malloc_using_sv(STRLEN len)
 {
     dTHX;
-    SV *sv = newSV(len);
+    SV *sv = newSV(len ? len : 1);
     void *p = SvPVX(sv);
     memzero(p, len);
     return p;


### PR DESCRIPTION
newSV(0) returns undef, scalar without PV slot. newSV(len) for len > 0
returns scalar with len+1 bytes in PV slot.

This change fixes calling malloc_using_sv(0) which may happen by calling
savepv_using_sv("").