### PR TITLE
Correct argument names of XS preparse()

### DIFF
--- a/DBI.xs
+++ b/DBI.xs
@@ -5055,11 +5055,11 @@ connected(...)
 
 
 SV *
-preparse(dbh, statement, ps_accept, ps_return, foo=Nullch)
+preparse(dbh, statement, ps_return, ps_accept, foo=Nullch)
     SV *        dbh
     char *      statement
-    IV          ps_accept
     IV          ps_return
+    IV          ps_accept
     void        *foo
 
 


### PR DESCRIPTION
preparse C function had prototype:

SV * preparse(SV *dbh, const char *statement, IV ps_return, IV ps_accept, void *foo);

But XS function had a ps_return and ps_accept argument names swapped:

SV *
preparse(dbh, statement, ps_accept, ps_return, foo=Nullch)
    SV *        dbh

This patch corrects the discrepancy.