### PR TITLE
Make gcc version check with clang not misleading

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -102,8 +102,8 @@ my %opts = (
 $opts{CAPI} = 'TRUE' if $Config{archname} =~ /-object\b/i;
 
 if (my $gccversion = $Config{gccversion}) {	# ask gcc to be more pedantic
-    if ($gccversion =~ m/ Clang \d/) {
-      warn "WARNING: This is not GCC, but $gccversion. Not checking compiler version.\n";
+    if ($gccversion =~ m/ clang ([0-9][-0-9.]*)/i) {
+      print "Your perl was compiled with Clang (version $1). As this is not GCC, version checking is skipped.\n";
       # https://clang.llvm.org/docs/DiagnosticsReference.html
       $opts{DEFINE} .= ' -W -Wall -Wpointer-arith -Wbad-function-cast';
       $opts{DEFINE} .= ' -Wno-comment -Wno-sign-compare -Wno-cast-qual';

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -102,17 +102,30 @@ my %opts = (
 $opts{CAPI} = 'TRUE' if $Config{archname} =~ /-object\b/i;
 
 if (my $gccversion = $Config{gccversion}) {	# ask gcc to be more pedantic
-    warn "WARNING: Your GNU C $gccversion compiler is very old. Please upgrade it and rebuild perl.\n"
-	if $gccversion =~ m/^\D*(1|2\.[1-8])/;
-    print "Your perl was compiled with gcc (version $Config{gccversion}), okay.\n";
-    $gccversion =~ s/[^\d\.]//g; # just a number please
-    $opts{DEFINE} .= ' -W -Wall -Wpointer-arith -Wbad-function-cast';
-    $opts{DEFINE} .= ' -Wno-comment -Wno-sign-compare -Wno-cast-qual';
-    $opts{DEFINE} .= ' -Wmissing-noreturn -Wno-unused-parameter' if $gccversion ge "3.0";
-    if ($is_developer && $::opt_g) {
-        $opts{DEFINE} .= ' -DPERL_GCC_PEDANTIC -ansi -pedantic' if $gccversion ge "3.0";
-        $opts{DEFINE} .= ' -Wdisabled-optimization -Wformat'    if $gccversion ge "3.0";
-        $opts{DEFINE} .= ' -Wmissing-prototypes';
+    if ($gccversion =~ m/ Clang \d/) {
+      warn "WARNING: This is not GCC, but $gccversion. Not checking compiler version.\n";
+      # https://clang.llvm.org/docs/DiagnosticsReference.html
+      $opts{DEFINE} .= ' -W -Wall -Wpointer-arith -Wbad-function-cast';
+      $opts{DEFINE} .= ' -Wno-comment -Wno-sign-compare -Wno-cast-qual';
+      $opts{DEFINE} .= ' -Wmissing-noreturn -Wno-unused-parameter';
+      $opts{DEFINE} .= ' -Wno-compound-token-split-by-macro -Wno-constant-conversion';
+      $opts{DEFINE} .= ' -Wno-implicit-const-int-float-conversion';
+      if ($is_developer && $::opt_g) {
+          $opts{DEFINE} .= ' -Wmissing-prototypes';
+      }
+    } else {
+      warn "WARNING: Your GNU C $gccversion compiler is very old. Please upgrade it and rebuild perl.\n"
+          if $gccversion =~ m/^\D*(1|2\.[1-8])/;
+      print "Your perl was compiled with gcc (version $Config{gccversion}), okay.\n";
+      $gccversion =~ s/[^\d\.]//g; # just a number please
+      $opts{DEFINE} .= ' -W -Wall -Wpointer-arith -Wbad-function-cast';
+      $opts{DEFINE} .= ' -Wno-comment -Wno-sign-compare -Wno-cast-qual';
+      $opts{DEFINE} .= ' -Wmissing-noreturn -Wno-unused-parameter' if $gccversion ge "3.0";
+      if ($is_developer && $::opt_g) {
+          $opts{DEFINE} .= ' -DPERL_GCC_PEDANTIC -ansi -pedantic' if $gccversion ge "3.0";
+          $opts{DEFINE} .= ' -Wdisabled-optimization -Wformat'    if $gccversion ge "3.0";
+          $opts{DEFINE} .= ' -Wmissing-prototypes';
+      }
     }
 }
 


### PR DESCRIPTION
On FreeBSD 14.0 perl is build with Clang 16.0.6 and not with GCC

This leads to this config:
```
% perl -e 'use Config; print "cc=$Config{\"cc\"}\ngccversion=$Config{\"gccversion\"}\n"'
cc=cc
gccversion=FreeBSD Clang 16.0.6 (https://github.com/llvm/llvm-project.git llvmorg-16.0.6-0-g7cbf1a259152)
```

And from the `perl Makefile.PL` output:
```
WARNING: Your GNU C FreeBSD Clang 16.0.6 (https://github.com/llvm/llvm-project.git llvmorg-16.0.6-0-g7cbf1a259152) compiler is very old. Please upgrade it and rebuild perl.
Your perl was compiled with gcc (version FreeBSD Clang 16.0.6 (https://github.com/llvm/llvm-project.git llvmorg-16.0.6-0-g7cbf1a259152)), okay.
```

Unfortunately we can't simply check `$Config{'cc'}` as that simply says `cc` and not `clang` or something that identifies the compiler.

Not sure what options we should set in `$opts{DEFINE}` for Clang. I've tried to make the current version build without warnings.