### PR TITLE
don't leak $_ after callback execution

### DIFF
--- a/DBI.xs
+++ b/DBI.xs
@@ -3605,10 +3605,8 @@ XS(XS_DBI_dispatch)
 
         /* The callback code can undef $_ to indicate to skip dispatch */
         skip_dispatch = !SvOK(DEFSV);
-        /* put $_ back now, but with an incremented ref count to compensate
-         * for the ref count decrement that will happen when we exit the scope.
-         */
-        DEFSV_set(SvREFCNT_inc(orig_defsv));
+        /* put $_ back now */
+        DEFSV_set(orig_defsv);
 
         if (trace_level)
             PerlIO_printf(DBILOGFP, "%c   }} %s callback %s returned%s\n",


### PR DESCRIPTION
The code responsible for executing callbacks (as in the $h->{Callbacks} feature) saves a copy of `*_{SCALAR}` (that is, the scalar slot of the `*_ `typeglob), replaces it with a reference to a temporary scalar (containing the name of the method being called), invokes the callback, and then restores the old `*_{SCALAR}`. This works like manually localizing (and then unlocalizing) `$_`.

However, before restoring the old `$_`, the code would increment its reference count "to compensate for the ref count decrement that will happen when we exit the scope". As far as I can tell, this never made any sense: `$_` is a global variable and we never decrement its reference count. All this did is increment the reference count of `$_` for no reason. This was usually harmless: `$_` is a global variable anyway. But if `$_` is localized (explicitly or by `for (...)`) when a callback runs, the local value of `$_` would leak.

Fix the leak by removing the spurious SvREFCNT_inc.

Fixes RT#144526.