### PR TITLE
Replace "use vars" with "our"

### DIFF
--- a/DBI.pm
+++ b/DBI.pm
@@ -10,8 +10,12 @@ package DBI;
 
 require 5.008_001;
 
+use strict;
+use warnings;
+
+our ($XS_VERSION, $VERSION);
 BEGIN {
-our $XS_VERSION = our $VERSION = "1.644"; # ==> ALSO update the version in the pod text below!
+$XS_VERSION = $VERSION = "1.644"; # ==> ALSO update the version in the pod text below!
 $VERSION = eval $VERSION;
 }
 
@@ -175,6 +179,7 @@ use Carp();
 use XSLoader ();
 use Exporter ();
 
+our (@ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 BEGIN {
 @ISA = qw(Exporter);
 
@@ -276,7 +281,7 @@ else {
     XSLoader::load( 'DBI', $XS_VERSION);
 }
 
-$EXPORT_TAGS{preparse_flags} = [ grep { /^DBIpp_\w\w_/ } keys %{__PACKAGE__."::"} ];
+$EXPORT_TAGS{preparse_flags} = [ grep { /^DBIpp_\w\w_/ } keys %DBI:: ];
 
 Exporter::export_ok_tags(keys %EXPORT_TAGS);
 
@@ -287,9 +292,6 @@ for (qw(trace_msg set_err parse_trace_flag parse_trace_flags)) {
   no strict;
   *$_ = \&{"DBD::_::common::$_"};
 }
-
-use strict;
-use warnings;
 
 DBI->trace(split /=/, $ENV{DBI_TRACE}, 2) if $ENV{DBI_TRACE};
 
@@ -1451,7 +1453,7 @@ sub _new_sth {	# called by DBD::<drivername>::db::prepare)
 
 {   package		# hide from PAUSE
 	DBD::_::dr;	# ====== DRIVER ======
-    @DBD::_::dr::ISA = qw(DBD::_::common);
+    our @ISA = qw(DBD::_::common);
     use strict;
 
     sub default_user {
@@ -1516,7 +1518,7 @@ sub _new_sth {	# called by DBD::<drivername>::db::prepare)
 
 {   package		# hide from PAUSE
 	DBD::_::db;	# ====== DATABASE ======
-    @DBD::_::db::ISA = qw(DBD::_::common);
+    our @ISA = qw(DBD::_::common);
     use strict;
 
     sub clone {
@@ -1838,7 +1840,7 @@ sub _new_sth {	# called by DBD::<drivername>::db::prepare)
 
 {   package		# hide from PAUSE
 	DBD::_::st;	# ====== STATEMENT ======
-    @DBD::_::st::ISA = qw(DBD::_::common);
+    our @ISA = qw(DBD::_::common);
     use strict;
 
     sub bind_param { Carp::croak("Can't bind_param, not implement by driver") }
@@ -7697,12 +7699,10 @@ can be found in F<t/subclass.t> in the DBI distribution.
   use strict;
 
   use DBI;
-  use vars qw(@ISA);
-  @ISA = qw(DBI);
+  our @ISA = qw(DBI);
 
   package MySubDBI::db;
-  use vars qw(@ISA);
-  @ISA = qw(DBI::db);
+  our @ISA = qw(DBI::db);
 
   sub prepare {
     my ($dbh, @args) = @_;
@@ -7713,8 +7713,7 @@ can be found in F<t/subclass.t> in the DBI distribution.
   }
 
   package MySubDBI::st;
-  use vars qw(@ISA);
-  @ISA = qw(DBI::st);
+  our @ISA = qw(DBI::st);
 
   sub fetch {
     my ($sth, @args) = @_;

--- a/doc/DBI.3
+++ b/doc/DBI.3
@@ -6242,12 +6242,10 @@ can be found in \fIt/subclass.t\fR in the DBI distribution.
 \&  use strict;
 \&
 \&  use DBI;
-\&  use vars qw(@ISA);
-\&  @ISA = qw(DBI);
+\&  our @ISA = qw(DBI);
 \&
 \&  package MySubDBI::db;
-\&  use vars qw(@ISA);
-\&  @ISA = qw(DBI::db);
+\&  our @ISA = qw(DBI::db);
 \&
 \&  sub prepare {
 \&    my ($dbh, @args) = @_;
@@ -6258,8 +6256,7 @@ can be found in \fIt/subclass.t\fR in the DBI distribution.
 \&  }
 \&
 \&  package MySubDBI::st;
-\&  use vars qw(@ISA);
-\&  @ISA = qw(DBI::st);
+\&  our @ISA = qw(DBI::st);
 \&
 \&  sub fetch {
 \&    my ($sth, @args) = @_;

--- a/doc/DBI.html
+++ b/doc/DBI.html
@@ -4059,12 +4059,10 @@ if ( $failed ) {
 use strict;
 
 use DBI;
-use vars qw(@ISA);
-@ISA = qw(DBI);
+our @ISA = qw(DBI);
 
 package MySubDBI::db;
-use vars qw(@ISA);
-@ISA = qw(DBI::db);
+our @ISA = qw(DBI::db);
 
 sub prepare {
   my ($dbh, @args) = @_;
@@ -4075,8 +4073,7 @@ sub prepare {
 }
 
 package MySubDBI::st;
-use vars qw(@ISA);
-@ISA = qw(DBI::st);
+our @ISA = qw(DBI::st);
 
 sub fetch {
   my ($sth, @args) = @_;

--- a/doc/DBI.md
+++ b/doc/DBI.md
@@ -5607,12 +5607,10 @@ can be found in `t/subclass.t` in the DBI distribution.
     use strict;
 
     use DBI;
-    use vars qw(@ISA);
-    @ISA = qw(DBI);
+    our @ISA = qw(DBI);
 
     package MySubDBI::db;
-    use vars qw(@ISA);
-    @ISA = qw(DBI::db);
+    our @ISA = qw(DBI::db);
 
     sub prepare {
       my ($dbh, @args) = @_;
@@ -5623,8 +5621,7 @@ can be found in `t/subclass.t` in the DBI distribution.
     }
 
     package MySubDBI::st;
-    use vars qw(@ISA);
-    @ISA = qw(DBI::st);
+    our @ISA = qw(DBI::st);
 
     sub fetch {
       my ($sth, @args) = @_;

--- a/doc/DBI::DBD.3
+++ b/doc/DBI::DBD.3
@@ -659,9 +659,8 @@ The header
 \&  package DBD::File;
 \&
 \&  use strict;
-\&  use vars qw($VERSION $drh);
 \&
-\&  $VERSION = "1.23.00"  # Version number of DBD::File
+\&  our $VERSION = "1.23.00"  # Version number of DBD::File
 .Ve
 .PP
 This is where the version number of your driver is specified, and is
@@ -678,7 +677,7 @@ very common).
 For Subversion you could use:
 .PP
 .Vb 1
-\&  $VERSION = "12.012346";
+\&  our $VERSION = "12.012346";
 .Ve
 .PP
 (use lots of leading zeros on the second portion so if you move the code to a
@@ -686,14 +685,14 @@ shared repository like svn.perl.org the much larger revision numbers won\*(Aqt
 cause a problem, at least not for a few years).  For RCS or CVS you can use:
 .PP
 .Vb 1
-\&  $VERSION = "11.22";
+\&  our $VERSION = "11.22";
 .Ve
 .PP
 which pads out the fractional part with leading zeros so all is well
 (so long as you don\*(Aqt go past x.99)
 .PP
 .Vb 1
-\&  $drh = undef;         # holds driver handle once initialized
+\&  our $drh = undef;         # holds driver handle once initialized
 .Ve
 .PP
 This is where the driver handle will be stored, once created.

--- a/doc/DBI::DBD.html
+++ b/doc/DBI::DBD.html
@@ -621,9 +621,8 @@ Jonathan Leffler E&lt;lt&gt;F&lt;jleffler@informix.com&gt;E&lt;gt&gt;.
 <pre><code>package DBD::File;
 
 use strict;
-use vars qw($VERSION $drh);
 
-$VERSION = &quot;1.23.00&quot;  # Version number of DBD::File</code></pre>
+our $VERSION = &quot;1.23.00&quot;  # Version number of DBD::File</code></pre>
 
 <p>This is where the version number of your driver is specified, and is where <i>Makefile.PL</i> looks for this information. Please ensure that any other modules added with your driver are also version stamped so that CPAN does not get confused.</p>
 
@@ -631,15 +630,15 @@ $VERSION = &quot;1.23.00&quot;  # Version number of DBD::File</code></pre>
 
 <p>For Subversion you could use:</p>
 
-<pre><code>$VERSION = &quot;12.012346&quot;;</code></pre>
+<pre><code>our $VERSION = &quot;12.012346&quot;;</code></pre>
 
 <p>(use lots of leading zeros on the second portion so if you move the code to a shared repository like svn.perl.org the much larger revision numbers won&#39;t cause a problem, at least not for a few years). For RCS or CVS you can use:</p>
 
-<pre><code>$VERSION = &quot;11.22&quot;;</code></pre>
+<pre><code>our $VERSION = &quot;11.22&quot;;</code></pre>
 
 <p>which pads out the fractional part with leading zeros so all is well (so long as you don&#39;t go past x.99)</p>
 
-<pre><code>$drh = undef;         # holds driver handle once initialized</code></pre>
+<pre><code>our $drh = undef;         # holds driver handle once initialized</code></pre>
 
 <p>This is where the driver handle will be stored, once created. Note that you may assume there is only one handle for your driver.</p>
 

--- a/doc/DBI::DBD.md
+++ b/doc/DBI::DBD.md
@@ -573,9 +573,8 @@ or really specific to the **DBD::File** package.
     package DBD::File;
 
     use strict;
-    use vars qw($VERSION $drh);
 
-    $VERSION = "1.23.00"  # Version number of DBD::File
+    our $VERSION = "1.23.00"  # Version number of DBD::File
 
 This is where the version number of your driver is specified, and is
 where `Makefile.PL` looks for this information. Please ensure that any
@@ -590,18 +589,18 @@ very common).
 
 For Subversion you could use:
 
-    $VERSION = "12.012346";
+    our $VERSION = "12.012346";
 
 (use lots of leading zeros on the second portion so if you move the code to a
 shared repository like svn.perl.org the much larger revision numbers won't
 cause a problem, at least not for a few years).  For RCS or CVS you can use:
 
-    $VERSION = "11.22";
+    our $VERSION = "11.22";
 
 which pads out the fractional part with leading zeros so all is well
 (so long as you don't go past x.99)
 
-    $drh = undef;         # holds driver handle once initialized
+    our $drh = undef;         # holds driver handle once initialized
 
 This is where the driver handle will be stored, once created.
 Note that you may assume there is only one handle for your driver.

--- a/doc/DBI::DBD::SqlEngine.3
+++ b/doc/DBI::DBD::SqlEngine.3
@@ -82,14 +82,14 @@ DBI::DBD::SqlEngine \- Base class for DBI drivers without their own SQL engine
 \&
 \&    package DBD::myDriver::dr;
 \&
-\&    @ISA = qw(DBI::DBD::SqlEngine::dr);
+\&    our @ISA = qw(DBI::DBD::SqlEngine::dr);
 \&
 \&    sub data_sources { ... }
 \&    ...
 \&
 \&    package DBD::myDriver::db;
 \&
-\&    @ISA = qw(DBI::DBD::SqlEngine::db);
+\&    our @ISA = qw(DBI::DBD::SqlEngine::db);
 \&
 \&    sub init_valid_attributes { ... }
 \&    sub init_default_attributes { ... }
@@ -101,20 +101,20 @@ DBI::DBD::SqlEngine \- Base class for DBI drivers without their own SQL engine
 \&
 \&    package DBD::myDriver::st;
 \&
-\&    @ISA = qw(DBI::DBD::SqlEngine::st);
+\&    our @ISA = qw(DBI::DBD::SqlEngine::st);
 \&
 \&    sub FETCH { ... }
 \&    sub STORE { ... }
 \&
 \&    package DBD::myDriver::Statement;
 \&
-\&    @ISA = qw(DBI::DBD::SqlEngine::Statement);
+\&    our @ISA = qw(DBI::DBD::SqlEngine::Statement);
 \&
 \&    sub open_table { ... }
 \&
 \&    package DBD::myDriver::Table;
 \&
-\&    @ISA = qw(DBI::DBD::SqlEngine::Table);
+\&    our @ISA = qw(DBI::DBD::SqlEngine::Table);
 \&
 \&    sub new { ... }
 .Ve

--- a/doc/DBI::DBD::SqlEngine.html
+++ b/doc/DBI::DBD::SqlEngine.html
@@ -109,14 +109,14 @@ sub driver
 
 package DBD::myDriver::dr;
 
-@ISA = qw(DBI::DBD::SqlEngine::dr);
+our @ISA = qw(DBI::DBD::SqlEngine::dr);
 
 sub data_sources { ... }
 ...
 
 package DBD::myDriver::db;
 
-@ISA = qw(DBI::DBD::SqlEngine::db);
+our @ISA = qw(DBI::DBD::SqlEngine::db);
 
 sub init_valid_attributes { ... }
 sub init_default_attributes { ... }
@@ -128,20 +128,20 @@ sub get_avail_tables { ... }
 
 package DBD::myDriver::st;
 
-@ISA = qw(DBI::DBD::SqlEngine::st);
+our @ISA = qw(DBI::DBD::SqlEngine::st);
 
 sub FETCH { ... }
 sub STORE { ... }
 
 package DBD::myDriver::Statement;
 
-@ISA = qw(DBI::DBD::SqlEngine::Statement);
+our @ISA = qw(DBI::DBD::SqlEngine::Statement);
 
 sub open_table { ... }
 
 package DBD::myDriver::Table;
 
-@ISA = qw(DBI::DBD::SqlEngine::Table);
+our @ISA = qw(DBI::DBD::SqlEngine::Table);
 
 sub new { ... }</code></pre>
 

--- a/doc/DBI::DBD::SqlEngine.md
+++ b/doc/DBI::DBD::SqlEngine.md
@@ -18,14 +18,14 @@ DBI::DBD::SqlEngine - Base class for DBI drivers without their own SQL engine
 
     package DBD::myDriver::dr;
 
-    @ISA = qw(DBI::DBD::SqlEngine::dr);
+    our @ISA = qw(DBI::DBD::SqlEngine::dr);
 
     sub data_sources { ... }
     ...
 
     package DBD::myDriver::db;
 
-    @ISA = qw(DBI::DBD::SqlEngine::db);
+    our @ISA = qw(DBI::DBD::SqlEngine::db);
 
     sub init_valid_attributes { ... }
     sub init_default_attributes { ... }
@@ -37,20 +37,20 @@ DBI::DBD::SqlEngine - Base class for DBI drivers without their own SQL engine
 
     package DBD::myDriver::st;
 
-    @ISA = qw(DBI::DBD::SqlEngine::st);
+    our @ISA = qw(DBI::DBD::SqlEngine::st);
 
     sub FETCH { ... }
     sub STORE { ... }
 
     package DBD::myDriver::Statement;
 
-    @ISA = qw(DBI::DBD::SqlEngine::Statement);
+    our @ISA = qw(DBI::DBD::SqlEngine::Statement);
 
     sub open_table { ... }
 
     package DBD::myDriver::Table;
 
-    @ISA = qw(DBI::DBD::SqlEngine::Table);
+    our @ISA = qw(DBI::DBD::SqlEngine::Table);
 
     sub new { ... }
 

--- a/doc/DBI::SQL::Nano.3
+++ b/doc/DBI::SQL::Nano.3
@@ -208,8 +208,7 @@ the table object, as well as SQL::Statement expects.
 .Vb 1
 \&  package Your::Table;
 \&
-\&  use vars qw(@ISA);
-\&  @ISA = qw(DBI::SQL::Nano::Table);
+\&  our @ISA = qw(DBI::SQL::Nano::Table);
 \&
 \&  sub drop ($$)        { ... }
 \&  sub fetch_row ($$$)  { ... }

--- a/doc/DBI::SQL::Nano.html
+++ b/doc/DBI::SQL::Nano.html
@@ -151,8 +151,7 @@ Angle brackets &lt;&gt; indicate items defined elsewhere in the BNF.
 
 <pre><code>package Your::Table;
 
-use vars qw(@ISA);
-@ISA = qw(DBI::SQL::Nano::Table);
+our @ISA = qw(DBI::SQL::Nano::Table);
 
 sub drop ($$)        { ... }
 sub fetch_row ($$$)  { ... }

--- a/doc/DBI::SQL::Nano.md
+++ b/doc/DBI::SQL::Nano.md
@@ -140,8 +140,7 @@ the table object, as well as SQL::Statement expects.
 
     package Your::Table;
 
-    use vars qw(@ISA);
-    @ISA = qw(DBI::SQL::Nano::Table);
+    our @ISA = qw(DBI::SQL::Nano::Table);
 
     sub drop ($$)        { ... }
     sub fetch_row ($$$)  { ... }

--- a/lib/DBD/DBM.pm
+++ b/lib/DBD/DBM.pm
@@ -24,9 +24,9 @@ use warnings;
 package DBD::DBM;
 #################
 use base qw( DBD::File );
-use vars qw($VERSION $ATTRIBUTION $drh $methods_already_installed);
-$VERSION     = '0.08';
-$ATTRIBUTION = 'DBD::DBM by Jens Rehsack';
+our ($drh,$methods_already_installed);
+our $VERSION     = '0.08';
+our $ATTRIBUTION = 'DBD::DBM by Jens Rehsack';
 
 # no need to have driver() unless you need private methods
 #
@@ -62,8 +62,8 @@ sub CLONE
 #####################
 package DBD::DBM::dr;
 #####################
-$DBD::DBM::dr::imp_data_size = 0;
-@DBD::DBM::dr::ISA           = qw(DBD::File::dr);
+our $imp_data_size = 0;
+our @ISA           = qw(DBD::File::dr);
 
 # you could put some :dr private methods here
 
@@ -74,8 +74,8 @@ $DBD::DBM::dr::imp_data_size = 0;
 #####################
 package DBD::DBM::db;
 #####################
-$DBD::DBM::db::imp_data_size = 0;
-@DBD::DBM::db::ISA           = qw(DBD::File::db);
+our $imp_data_size = 0;
+our @ISA           = qw(DBD::File::db);
 
 use Carp qw/carp/;
 
@@ -208,8 +208,8 @@ sub get_dbm_versions
 #####################
 package DBD::DBM::st;
 #####################
-$DBD::DBM::st::imp_data_size = 0;
-@DBD::DBM::st::ISA           = qw(DBD::File::st);
+our $imp_data_size = 0;
+our @ISA           = qw(DBD::File::st);
 
 sub FETCH
 {
@@ -246,7 +246,7 @@ sub dbm_schema
 package DBD::DBM::Statement;
 ############################
 
-@DBD::DBM::Statement::ISA = qw(DBD::File::Statement);
+our @ISA = qw(DBD::File::Statement);
 
 ########################
 package DBD::DBM::Table;
@@ -254,7 +254,7 @@ package DBD::DBM::Table;
 use Carp;
 use Fcntl;
 
-@DBD::DBM::Table::ISA = qw(DBD::File::Table);
+our @ISA = qw(DBD::File::Table);
 
 my $dirfext = $^O eq 'VMS' ? '.sdbm_dir' : '.dir';
 

--- a/lib/DBD/File.pm
+++ b/lib/DBD/File.pm
@@ -34,11 +34,10 @@ use warnings;
 
 use base qw( DBI::DBD::SqlEngine );
 use Carp;
-use vars qw( @ISA $VERSION $drh );
 
-$VERSION = "0.44";
+our $VERSION = "0.44";
 
-$drh = undef;		# holds driver handle(s) once initialized
+our $drh = undef;		# holds driver handle(s) once initialized
 
 sub driver ($;$)
 {
@@ -84,12 +83,10 @@ package DBD::File::dr;
 use strict;
 use warnings;
 
-use vars qw( @ISA $imp_data_size );
-
 use Carp;
 
-@DBD::File::dr::ISA           = qw( DBI::DBD::SqlEngine::dr );
-$DBD::File::dr::imp_data_size = 0;
+our @ISA           = qw( DBI::DBD::SqlEngine::dr );
+our $imp_data_size = 0;
 
 sub dsn_quote
 {
@@ -148,15 +145,13 @@ package DBD::File::db;
 use strict;
 use warnings;
 
-use vars qw( @ISA $imp_data_size );
-
 use Carp;
 require File::Spec;
 require Cwd;
 use Scalar::Util qw( refaddr ); # in CORE since 5.7.3
 
-@DBD::File::db::ISA           = qw( DBI::DBD::SqlEngine::db );
-$DBD::File::db::imp_data_size = 0;
+our @ISA           = qw( DBI::DBD::SqlEngine::db );
+our $imp_data_size = 0;
 
 sub data_sources
 {
@@ -302,10 +297,8 @@ package DBD::File::st;
 use strict;
 use warnings;
 
-use vars qw( @ISA $imp_data_size );
-
-@DBD::File::st::ISA           = qw( DBI::DBD::SqlEngine::st );
-$DBD::File::st::imp_data_size = 0;
+our @ISA           = qw( DBI::DBD::SqlEngine::st );
+our $imp_data_size = 0;
 
 my %supported_attrs = (
     TYPE      => 1,
@@ -397,7 +390,7 @@ use warnings;
 
 use IO::Dir;
 
-@DBD::File::TableSource::FileSystem::ISA = "DBI::DBD::SqlEngine::TableSource";
+our @ISA = "DBI::DBD::SqlEngine::TableSource";
 
 sub data_sources
 {
@@ -488,7 +481,7 @@ use warnings;
 
 use Carp;
 
-@DBD::File::DataSource::Stream::ISA = "DBI::DBD::SqlEngine::DataSource";
+our @ISA = "DBI::DBD::SqlEngine::DataSource";
 
 # We may have a working flock () built-in but that doesn't mean that locking
 # will work on NFS (flock () may hang hard)
@@ -577,7 +570,7 @@ package DBD::File::DataSource::File;
 use strict;
 use warnings;
 
-@DBD::File::DataSource::File::ISA = "DBD::File::DataSource::Stream";
+our @ISA = "DBD::File::DataSource::Stream";
 
 use Carp;
 
@@ -770,7 +763,7 @@ package DBD::File::Statement;
 use strict;
 use warnings;
 
-@DBD::File::Statement::ISA = qw( DBI::DBD::SqlEngine::Statement );
+our @ISA = qw( DBI::DBD::SqlEngine::Statement );
 
 # ====== SQL::TABLE ============================================================
 
@@ -786,7 +779,7 @@ require File::Spec;
 require Cwd;
 require Scalar::Util;
 
-@DBD::File::Table::ISA = qw( DBI::DBD::SqlEngine::Table );
+our @ISA = qw( DBI::DBD::SqlEngine::Table );
 
 # ====== UTILITIES ============================================================
 

--- a/lib/DBD/File/HowTo.pod
+++ b/lib/DBD/File/HowTo.pod
@@ -46,45 +46,34 @@ C<foo_> is assumed.
 
     use strict;
     use warnings;
-    use vars qw(@ISA $VERSION);
     use base qw(DBD::File);
 
     use DBI ();
 
-    $VERSION = "0.001";
+    our $VERSION = "0.001";
 
     package DBD::Foo::dr;
 
-    use vars qw(@ISA $imp_data_size);
-
-    @ISA = qw(DBD::File::dr);
-    $imp_data_size = 0;
+    our @ISA = qw(DBD::File::dr);
+    our $imp_data_size = 0;
 
     package DBD::Foo::db;
 
-    use vars qw(@ISA $imp_data_size);
-
-    @ISA = qw(DBD::File::db);
-    $imp_data_size = 0;
+    our @ISA = qw(DBD::File::db);
+    our $imp_data_size = 0;
 
     package DBD::Foo::st;
 
-    use vars qw(@ISA $imp_data_size);
-
-    @ISA = qw(DBD::File::st);
-    $imp_data_size = 0;
+    our @ISA = qw(DBD::File::st);
+    our $imp_data_size = 0;
 
     package DBD::Foo::Statement;
 
-    use vars qw(@ISA);
-
-    @ISA = qw(DBD::File::Statement);
+    our @ISA = qw(DBD::File::Statement);
 
     package DBD::Foo::Table;
 
-    use vars qw(@ISA);
-
-    @ISA = qw(DBD::File::Table);
+    our @ISA = qw(DBD::File::Table);
 
     1;
 

--- a/lib/DBD/Mem.pm
+++ b/lib/DBD/Mem.pm
@@ -22,9 +22,9 @@ use strict;
 package DBD::Mem;
 #################
 use base qw( DBI::DBD::SqlEngine );
-use vars qw($VERSION $ATTRIBUTION $drh);
-$VERSION     = '0.001';
-$ATTRIBUTION = 'DBD::Mem by Jens Rehsack';
+our $drh;
+our $VERSION     = '0.001';
+our $ATTRIBUTION = 'DBD::Mem by Jens Rehsack';
 
 # no need to have driver() unless you need private methods
 #
@@ -49,8 +49,8 @@ sub CLONE
 #####################
 package DBD::Mem::dr;
 #####################
-$DBD::Mem::dr::imp_data_size = 0;
-@DBD::Mem::dr::ISA           = qw(DBI::DBD::SqlEngine::dr);
+our $imp_data_size = 0;
+our @ISA           = qw(DBI::DBD::SqlEngine::dr);
 
 # you could put some :dr private methods here
 
@@ -61,8 +61,8 @@ $DBD::Mem::dr::imp_data_size = 0;
 #####################
 package DBD::Mem::db;
 #####################
-$DBD::Mem::db::imp_data_size = 0;
-@DBD::Mem::db::ISA           = qw(DBI::DBD::SqlEngine::db);
+our $imp_data_size = 0;
+our @ISA           = qw(DBI::DBD::SqlEngine::db);
 
 use Carp qw/carp/;
 
@@ -131,7 +131,7 @@ our @ISA           = qw(DBI::DBD::SqlEngine::st);
 package DBD::Mem::Statement;
 ############################
 
-@DBD::Mem::Statement::ISA = qw(DBI::DBD::SqlEngine::Statement);
+our @ISA = qw(DBI::DBD::SqlEngine::Statement);
 
 
 sub open_table ($$$$$)
@@ -164,7 +164,7 @@ use warnings;
 
 use Carp;
 
-@DBD::Mem::DataSource::ISA = "DBI::DBD::SqlEngine::DataSource";
+our @ISA = "DBI::DBD::SqlEngine::DataSource";
 
 sub complete_table_name ($$;$)
 {
@@ -186,7 +186,7 @@ package DBD::Mem::Table;
 
 use Carp qw/croak/;
 
-@DBD::Mem::Table::ISA = qw(DBI::DBD::SqlEngine::Table);
+our @ISA = qw(DBI::DBD::SqlEngine::Table);
 
 use Carp qw(croak);
 

--- a/lib/DBD/Multiplex.pm
+++ b/lib/DBD/Multiplex.pm
@@ -61,11 +61,10 @@ package DBD::Multiplex;
 use DBI ();
 
 use strict;
-use vars qw($VERSION $drh);
 
-$VERSION = "2.014123";
+our $VERSION = "2.014123";
 
-$drh = undef;	# Holds driver handle once it has been initialized.
+our $drh = undef;	# Holds driver handle once it has been initialized.
 
 #########################################
 # The driver handle constructor.

--- a/lib/DBD/Proxy.pm
+++ b/lib/DBD/Proxy.pm
@@ -31,7 +31,7 @@ DBI->require_version(1.0201);
 use RPC::PlClient 0.2000; # XXX change to 0.2017 once it's released
 
 {	package DBD::Proxy::RPC::PlClient;
-    	@DBD::Proxy::RPC::PlClient::ISA = qw(RPC::PlClient);
+	our @ISA = qw(RPC::PlClient);
 	sub Call {
 	    my $self = shift;
 	    if ($self->{debug}) {
@@ -46,13 +46,11 @@ use RPC::PlClient 0.2000; # XXX change to 0.2017 once it's released
 
 package DBD::Proxy;
 
-use vars qw($VERSION $drh %ATTR);
+our $VERSION = "0.2004";
 
-$VERSION = "0.2004";
+our $drh = undef;		# holds driver handle once initialised
 
-$drh = undef;		# holds driver handle once initialised
-
-%ATTR = (	# common to db & st, see also %ATTR in DBD::Proxy::db & ::st
+our %ATTR = (	# common to db & st, see also %ATTR in DBD::Proxy::db & ::st
     'Warn'	=> 'local',
     'Active'	=> 'local',
     'Kids'	=> 'local',
@@ -93,7 +91,7 @@ sub proxy_set_err {
 
 package DBD::Proxy::dr; # ====== DRIVER ======
 
-$DBD::Proxy::dr::imp_data_size = 0;
+our $imp_data_size = 0;
 
 sub connect ($$;$$) {
     my($drh, $dsn, $user, $auth, $attr)= @_;
@@ -219,7 +217,7 @@ sub DESTROY { undef }
 
 package DBD::Proxy::db; # ====== DATABASE ======
 
-$DBD::Proxy::db::imp_data_size = 0;
+our $imp_data_size = 0;
 
 # XXX probably many more methods need to be added here
 # in order to trigger our AUTOLOAD to redirect them to the server.
@@ -234,7 +232,7 @@ sub commit;
 sub rollback;
 sub ping;
 
-use vars qw(%ATTR $AUTOLOAD);
+our $AUTOLOAD;
 
 # inherited: STORE / FETCH against this class.
 # local:     STORE / FETCH against parent class.
@@ -243,7 +241,7 @@ use vars qw(%ATTR $AUTOLOAD);
 #
 # Note: Attribute names starting with 'proxy_' always treated as 'inherited'.
 #
-%ATTR = (	# see also %ATTR in DBD::Proxy::st
+our %ATTR = (	# see also %ATTR in DBD::Proxy::st
     %DBD::Proxy::ATTR,
     RowCacheSize => 'inherited',
     #AutoCommit => 'cached',
@@ -480,9 +478,7 @@ sub type_info_all {
 
 package DBD::Proxy::st; # ====== STATEMENT ======
 
-$DBD::Proxy::st::imp_data_size = 0;
-
-use vars qw(%ATTR);
+our $imp_data_size = 0;
 
 # inherited:  STORE to current object. FETCH from current if exists, else call up
 #              to the (proxy) database object.
@@ -493,7 +489,7 @@ use vars qw(%ATTR);
 #
 # Note: Attribute names starting with 'proxy_' always treated as 'inherited'.
 #
-%ATTR = (	# see also %ATTR in DBD::Proxy::db
+our %ATTR = (	# see also %ATTR in DBD::Proxy::db
     %DBD::Proxy::ATTR,
     'Database' => 'local',
     'RowsInCache' => 'local',

--- a/lib/DBI/Const/GetInfoReturn.pm
+++ b/lib/DBI/Const/GetInfoReturn.pm
@@ -14,10 +14,8 @@ use warnings;
 
 use Exporter ();
 
-use vars qw(@ISA @EXPORT @EXPORT_OK %GetInfoReturnTypes %GetInfoReturnValues);
-
-@ISA = qw(Exporter);
-@EXPORT = qw(%GetInfoReturnTypes %GetInfoReturnValues);
+our @ISA = qw(Exporter);
+our @EXPORT = qw(%GetInfoReturnTypes %GetInfoReturnValues);
 
 my
 $VERSION = "2.008697";
@@ -41,13 +39,13 @@ use DBI::Const::GetInfoType;
 use DBI::Const::GetInfo::ANSI ();
 use DBI::Const::GetInfo::ODBC ();
 
-%GetInfoReturnTypes =
+our %GetInfoReturnTypes =
 (
   %DBI::Const::GetInfo::ANSI::ReturnTypes
 , %DBI::Const::GetInfo::ODBC::ReturnTypes
 );
 
-%GetInfoReturnValues = ();
+our %GetInfoReturnValues = ();
 {
   my $A = \%DBI::Const::GetInfo::ANSI::ReturnValues;
   my $O = \%DBI::Const::GetInfo::ODBC::ReturnValues;

--- a/lib/DBI/Const/GetInfoType.pm
+++ b/lib/DBI/Const/GetInfoType.pm
@@ -14,10 +14,8 @@ use warnings;
 
 use Exporter ();
 
-use vars qw(@ISA @EXPORT @EXPORT_OK %GetInfoType);
-
-@ISA = qw(Exporter);
-@EXPORT = qw(%GetInfoType);
+our @ISA = qw(Exporter);
+our @EXPORT = qw(%GetInfoType);
 
 my
 $VERSION = "2.008697";
@@ -45,7 +43,7 @@ written here is guaranteed.
 use DBI::Const::GetInfo::ANSI ();	# liable to change
 use DBI::Const::GetInfo::ODBC ();	# liable to change
 
-%GetInfoType =
+our %GetInfoType =
 (
   %DBI::Const::GetInfo::ANSI::InfoTypes	# liable to change
 , %DBI::Const::GetInfo::ODBC::InfoTypes	# liable to change

--- a/lib/DBI/DBD.pm
+++ b/lib/DBI/DBD.pm
@@ -2,11 +2,11 @@ package DBI::DBD;
 # vim:ts=8:sw=4
 use strict;
 use warnings;
-use vars qw($VERSION);	# set $VERSION early so we don't confuse PAUSE/CPAN etc
 
+# set $VERSION early so we don't confuse PAUSE/CPAN etc
 # don't use Revision here because that's not in svn:keywords so that the
 # examples that use it below won't be messed up
-$VERSION = "12.015129";
+our $VERSION = "12.015129";
 
 # $Id: DBD.pm 15128 2012-02-04 20:51:39Z Tim $
 #
@@ -679,9 +679,8 @@ or really specific to the B<DBD::File> package.
   package DBD::File;
 
   use strict;
-  use vars qw($VERSION $drh);
 
-  $VERSION = "1.23.00"  # Version number of DBD::File
+  our $VERSION = "1.23.00"  # Version number of DBD::File
 
 This is where the version number of your driver is specified, and is
 where F<Makefile.PL> looks for this information. Please ensure that any
@@ -696,18 +695,18 @@ very common).
 
 For Subversion you could use:
 
-  $VERSION = "12.012346";
+  our $VERSION = "12.012346";
 
 (use lots of leading zeros on the second portion so if you move the code to a
 shared repository like svn.perl.org the much larger revision numbers won't
 cause a problem, at least not for a few years).  For RCS or CVS you can use:
 
-  $VERSION = "11.22";
+  our $VERSION = "11.22";
 
 which pads out the fractional part with leading zeros so all is well
 (so long as you don't go past x.99)
 
-  $drh = undef;         # holds driver handle once initialized
+  our $drh = undef;         # holds driver handle once initialized
 
 This is where the driver handle will be stored, once created.
 Note that you may assume there is only one handle for your driver.
@@ -3266,10 +3265,6 @@ use Carp;
 use Cwd;
 use File::Spec;
 use strict;
-use vars qw(
-    @ISA @EXPORT
-    $is_dbi
-);
 
 BEGIN {
     if ($^O eq 'VMS') {
@@ -3284,15 +3279,16 @@ BEGIN {
     }
 }
 
-@ISA = qw(Exporter);
+our @ISA = qw(Exporter);
 
-@EXPORT = qw(
+our @EXPORT = qw(
     dbd_dbi_dir
     dbd_dbi_arch_dir
     dbd_edit_mm_attribs
     dbd_postamble
 );
 
+our $is_dbi;
 BEGIN {
     $is_dbi = (-r 'DBI.pm' && -r 'DBI.xs' && -r 'DBIXS.h');
     require DBI unless $is_dbi;

--- a/lib/DBI/DBD/SqlEngine.pm
+++ b/lib/DBI/DBD/SqlEngine.pm
@@ -32,11 +32,11 @@ package DBI::DBD::SqlEngine;
 use strict;
 
 use Carp;
-use vars qw( @ISA $VERSION $drh %methods_installed);
+our %methods_installed;
 
-$VERSION = "0.06";
+our $VERSION = "0.06";
 
-$drh = undef;    # holds driver handle(s) once initialized
+our $drh = undef;    # holds driver handle(s) once initialized
 
 DBI->setup_driver("DBI::DBD::SqlEngine");    # only needed once but harmless to repeat
 
@@ -124,11 +124,9 @@ package DBI::DBD::SqlEngine::dr;
 use strict;
 use warnings;
 
-use vars qw(@ISA $imp_data_size);
-
 use Carp qw/carp/;
 
-$imp_data_size = 0;
+our $imp_data_size = 0;
 
 sub connect ($$;$$$)
 {
@@ -276,8 +274,6 @@ package DBI::DBD::SqlEngine::db;
 use strict;
 use warnings;
 
-use vars qw(@ISA $imp_data_size);
-
 use Carp;
 
 if ( eval { require Clone; } )
@@ -290,7 +286,7 @@ else
     *clone = \&Storable::dclone;
 }
 
-$imp_data_size = 0;
+our $imp_data_size = 0;
 
 sub ping
 {
@@ -1047,7 +1043,7 @@ package DBI::DBD::SqlEngine::TieMeta;
 
 use Carp qw(croak);
 require Tie::Hash;
-@DBI::DBD::SqlEngine::TieMeta::ISA = qw(Tie::Hash);
+our @ISA = qw(Tie::Hash);
 
 sub TIEHASH
 {
@@ -1116,7 +1112,7 @@ package DBI::DBD::SqlEngine::TieTables;
 
 use Carp qw(croak);
 require Tie::Hash;
-@DBI::DBD::SqlEngine::TieTables::ISA = qw(Tie::Hash);
+our @ISA = qw(Tie::Hash);
 
 sub TIEHASH
 {
@@ -1209,9 +1205,7 @@ package DBI::DBD::SqlEngine::st;
 use strict;
 use warnings;
 
-use vars qw(@ISA $imp_data_size);
-
-$imp_data_size = 0;
+our $imp_data_size = 0;
 
 sub bind_param ($$$;$)
 {
@@ -1444,7 +1438,7 @@ use warnings;
 
 use Carp;
 
-@DBI::DBD::SqlEngine::Statement::ISA = qw(DBI::SQL::Nano::Statement);
+our @ISA = qw(DBI::SQL::Nano::Statement);
 
 sub open_table ($$$$$)
 {
@@ -1490,7 +1484,7 @@ use warnings;
 
 use Carp;
 
-@DBI::DBD::SqlEngine::Table::ISA = qw(DBI::SQL::Nano::Table);
+our @ISA = qw(DBI::SQL::Nano::Table);
 
 sub bootstrap_table_meta
 {
@@ -1687,14 +1681,14 @@ DBI::DBD::SqlEngine - Base class for DBI drivers without their own SQL engine
 
     package DBD::myDriver::dr;
 
-    @ISA = qw(DBI::DBD::SqlEngine::dr);
+    our @ISA = qw(DBI::DBD::SqlEngine::dr);
 
     sub data_sources { ... }
     ...
 
     package DBD::myDriver::db;
 
-    @ISA = qw(DBI::DBD::SqlEngine::db);
+    our @ISA = qw(DBI::DBD::SqlEngine::db);
 
     sub init_valid_attributes { ... }
     sub init_default_attributes { ... }
@@ -1706,20 +1700,20 @@ DBI::DBD::SqlEngine - Base class for DBI drivers without their own SQL engine
 
     package DBD::myDriver::st;
 
-    @ISA = qw(DBI::DBD::SqlEngine::st);
+    our @ISA = qw(DBI::DBD::SqlEngine::st);
 
     sub FETCH { ... }
     sub STORE { ... }
 
     package DBD::myDriver::Statement;
 
-    @ISA = qw(DBI::DBD::SqlEngine::Statement);
+    our @ISA = qw(DBI::DBD::SqlEngine::Statement);
 
     sub open_table { ... }
 
     package DBD::myDriver::Table;
 
-    @ISA = qw(DBI::DBD::SqlEngine::Table);
+    our @ISA = qw(DBI::DBD::SqlEngine::Table);
 
     sub new { ... }
 

--- a/lib/DBI/DBD/SqlEngine/Developers.pod
+++ b/lib/DBI/DBD/SqlEngine/Developers.pod
@@ -114,7 +114,7 @@ interface:
 
   # invokes
   package DBD::DBM::dr;
-  @DBD::DBM::dr::ISA = qw(DBI::DBD::SqlEngine::dr);
+  our @ISA = qw(DBI::DBD::SqlEngine::dr);
 
   sub connect ($$;$$$)
   {
@@ -224,9 +224,9 @@ it is enough to do the basic initialization:
 
   package DBD:XXX::dr;
 
-  @DBD::XXX::dr::ISA = qw (DBI::DBD::SqlEngine::dr);
-  $DBD::XXX::dr::imp_data_size     = 0;
-  $DBD::XXX::dr::data_sources_attr = undef;
+  our @ISA = qw (DBI::DBD::SqlEngine::dr);
+  our $imp_data_size     = 0;
+  our $data_sources_attr = undef;
   $DBD::XXX::ATTRIBUTION = "DBD::XXX $DBD::XXX::VERSION by Hans Mustermann";
 
 =head3 Methods provided by C<< DBI::DBD::SqlEngine::dr >>:
@@ -249,7 +249,7 @@ C<init_default_attributes>. Modern drivers understand that and do early
 stage setup here after calling
 
   package DBD::Foo::db;
-  our @DBD::Foo::db::ISA = qw(DBI::DBD::SqlEngine::db);
+  our @ISA = qw(DBI::DBD::SqlEngine::db);
   
   sub init_default_attributes
   {

--- a/lib/DBI/DBD/SqlEngine/HowTo.pod
+++ b/lib/DBI/DBD/SqlEngine/HowTo.pod
@@ -46,45 +46,34 @@ For this guide, a prefix of C<foo_> is assumed.
 
     use strict;
     use warnings;
-    use vars qw($VERSION);
     use base qw(DBI::DBD::SqlEngine);
 
     use DBI ();
 
-    $VERSION = "0.001";
+    our $VERSION = "0.001";
 
     package DBD::Foo::dr;
 
-    use vars qw(@ISA $imp_data_size);
-
-    @ISA = qw(DBI::DBD::SqlEngine::dr);
-    $imp_data_size = 0;
+    our @ISA = qw(DBI::DBD::SqlEngine::dr);
+    our $imp_data_size = 0;
 
     package DBD::Foo::db;
 
-    use vars qw(@ISA $imp_data_size);
-
-    @ISA = qw(DBI::DBD::SqlEngine::db);
-    $imp_data_size = 0;
+    our @ISA = qw(DBI::DBD::SqlEngine::db);
+    our $imp_data_size = 0;
 
     package DBD::Foo::st;
 
-    use vars qw(@ISA $imp_data_size);
-
-    @ISA = qw(DBI::DBD::SqlEngine::st);
-    $imp_data_size = 0;
+    our @ISA = qw(DBI::DBD::SqlEngine::st);
+    our $imp_data_size = 0;
 
     package DBD::Foo::Statement;
 
-    use vars qw(@ISA);
-
-    @ISA = qw(DBI::DBD::SqlEngine::Statement);
+    our @ISA = qw(DBI::DBD::SqlEngine::Statement);
 
     package DBD::Foo::Table;
 
-    use vars qw(@ISA);
-
-    @ISA = qw(DBI::DBD::SqlEngine::Table);
+    our @ISA = qw(DBI::DBD::SqlEngine::Table);
 
     1;
 

--- a/lib/DBI/Profile.pm
+++ b/lib/DBI/Profile.pm
@@ -676,17 +676,16 @@ many forward references.  (Patches welcome!)
 
 use strict;
 use warnings;
-use vars qw(@ISA @EXPORT @EXPORT_OK $VERSION);
 use Exporter ();
 use UNIVERSAL ();
 use Carp;
 
 use DBI qw(dbi_time dbi_profile dbi_profile_merge_nodes dbi_profile_merge);
 
-$VERSION = "2.015065";
+our $VERSION = "2.015065";
 
-@ISA = qw(Exporter);
-@EXPORT = qw(
+our @ISA = qw(Exporter);
+our @EXPORT = qw(
     DBIprofile_Statement
     DBIprofile_MethodName
     DBIprofile_MethodClass
@@ -695,7 +694,7 @@ $VERSION = "2.015065";
     dbi_profile_merge
     dbi_time
 );
-@EXPORT_OK = qw(
+our @EXPORT_OK = qw(
     format_profile_thingy
 );
 
@@ -952,4 +951,3 @@ sub DESTROY {
 }
 
 1;
-

--- a/lib/DBI/ProxyServer.pm
+++ b/lib/DBI/ProxyServer.pm
@@ -41,10 +41,8 @@ package DBI::ProxyServer;
 #
 ############################################################################
 
-use vars qw($VERSION @ISA);
-
-$VERSION = "0.3005";
-@ISA = qw(RPC::PlServer DBI);
+our $VERSION = "0.3005";
+our @ISA = qw(RPC::PlServer DBI);
 
 
 # Most of the options below are set to default values, we note them here
@@ -246,12 +244,12 @@ sub main {
 
 package DBI::ProxyServer::dr;
 
-@DBI::ProxyServer::dr::ISA = qw(DBI::dr);
+our @ISA = qw(DBI::dr);
 
 
 package DBI::ProxyServer::db;
 
-@DBI::ProxyServer::db::ISA = qw(DBI::db);
+our @ISA = qw(DBI::db);
 
 sub prepare {
     my($dbh, $statement, $attr, $params, $proto_ver) = @_;
@@ -316,7 +314,7 @@ sub table_info {
 
 package DBI::ProxyServer::st;
 
-@DBI::ProxyServer::st::ISA = qw(DBI::st);
+our @ISA = qw(DBI::st);
 
 sub execute {
     my $sth = shift; my $params = shift; my $proto_ver = shift;

--- a/lib/DBI/SQL/Nano.pm
+++ b/lib/DBI/SQL/Nano.pm
@@ -20,7 +20,7 @@ package DBI::SQL::Nano;
 #######################
 use strict;
 use warnings;
-use vars qw( $VERSION $versions );
+our ( $VERSION, $versions );
 
 use Carp qw(croak);
 
@@ -951,8 +951,7 @@ the table object, as well as SQL::Statement expects.
 
   package Your::Table;
 
-  use vars qw(@ISA);
-  @ISA = qw(DBI::SQL::Nano::Table);
+  our @ISA = qw(DBI::SQL::Nano::Table);
 
   sub drop ($$)        { ... }
   sub fetch_row ($$$)  { ... }
@@ -1011,4 +1010,3 @@ either the GNU General Public License (GPL) or the Artistic License,
 as specified in the Perl README file.
 
 =cut
-

--- a/t/30subclass.t
+++ b/t/30subclass.t
@@ -18,14 +18,14 @@ my %my_methods;
 # This whole mechanism is new and experimental - it may change!
 
 package MyDBI;
-@MyDBI::ISA = qw(DBI);
+our @ISA = qw(DBI);
 
 # the MyDBI::dr::connect method is NOT called!
 # you can either override MyDBI::connect()
 # or use MyDBI::db::connected()
 
 package MyDBI::db;
-@MyDBI::db::ISA = qw(DBI::db);
+our @ISA = qw(DBI::db);
 
 sub prepare {
     my($dbh, @args) = @_;
@@ -37,7 +37,7 @@ sub prepare {
 
 
 package MyDBI::st;
-@MyDBI::st::ISA = qw(DBI::st);
+our @ISA = qw(DBI::st);
 
 sub fetch {
     my($sth, @args) = @_;

--- a/t/31methcache.t
+++ b/t/31methcache.t
@@ -65,7 +65,7 @@ sub Foo::local2 { [ "local2" ] };
 my $fetch_hook;
 {
     package Bar;
-    @Bar::ISA = qw(DBD::_::st);
+    our @ISA = qw(DBD::_::st);
     sub fetch { &$fetch_hook };
 }
 

--- a/t/50dbm_simple.t
+++ b/t/50dbm_simple.t
@@ -16,7 +16,7 @@ use Storable qw(dclone);
 my $using_dbd_gofer = ($ENV{DBI_AUTOPROXY}||'') =~ /^dbi:Gofer.*transport=/i;
 
 use DBI;
-use vars qw( @mldbm_types @dbm_types );
+my ( @mldbm_types, @dbm_types );
 
 BEGIN {
 

--- a/t/52dbm_complex.t
+++ b/t/52dbm_complex.t
@@ -16,7 +16,7 @@ use Storable qw(dclone);
 my $using_dbd_gofer = ( $ENV{DBI_AUTOPROXY} || '' ) =~ /^dbi:Gofer.*transport=/i;
 
 use DBI;
-use vars qw( @mldbm_types @dbm_types );
+my ( @mldbm_types, @dbm_types );
 
 BEGIN
 {


### PR DESCRIPTION
Use of this pragma is discouraged in favour of "our" under 5.06+.

Also move strict/warnings higher in DBI.pm to cover the two big BEGIN blocks, this caused a few other tweaks to code to compile under strict.

In a couple of tests vars was changed to my as package scope was obviously not needed.