### PR TITLE
Replace bogus non-ASCII char in MANIFEST

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -69,7 +69,7 @@ lib/DBI/ProfileSubs.pm
 lib/DBI/ProxyServer.pm		The proxy drivers server
 lib/DBI/PurePerl.pm		A DBI.xs emulation in Perl
 lib/DBI/SQL/Nano.pm		A 'smaller than micro' SQL parser
-lib/DBI/Util/_accessor.pm       A very¬cut-down version of Class::Accessor::Fast
+lib/DBI/Util/_accessor.pm       A very cut-down version of Class::Accessor::Fast
 lib/DBI/Util/CacheMemory.pm     A very cut-down version of Cache::Memory
 lib/DBI/W32ODBC.pm		An experimental DBI emulation layer for Win32::ODBC
 lib/Win32/DBIODBC.pm		An experimental Win32::ODBC emulation layer for DBI


### PR DESCRIPTION
I'm not what character it was, GitHub detects the file as latin1 prior to this change but clearly it ought to be a simple space based on the subsequent line with very similar wording.