### PR TITLE
Allow parallel builds to work.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -386,4 +386,10 @@ tgzdist:	changes spellcheck newdist dist
     return $xst;
     } # post_constants
 
+sub processPL {
+    my $super = shift->SUPER::processPL (@_);
+    $super =~ s/^(dbi\w+ :: dbi\w+\.PL pm_to_blib)/$1 \$(INST_DYNAMIC)/gm;
+    return $super;
+}
+
 1;


### PR DESCRIPTION
If the .so doesn't get built before we invoke the PL scripts, they may find an older version elsewhere in the path and fail with a "does not match bootstrap parameter" error. Thus, make a dependency so we don't run those PL scripts until we have the new .so ready.

Fixes https://github.com/perl5-dbi/dbi/issues/62