### PR TITLE
Fix cast warning in dbi_get_state

### DIFF
--- a/DBIXS.h
+++ b/DBIXS.h
@@ -495,7 +495,7 @@ typedef dbistate_t** (*_dbi_state_lval_t)(pTHX);
             CV *cv = get_cv("DBI::_dbi_state_lval", 0);                     \
             if (!cv)                                                        \
                 croak("Unable to get DBI state function. DBI not loaded."); \
-            dbi_state_lval_p = (_dbi_state_lval_t)CvXSUB(cv);               \
+            dbi_state_lval_p = (_dbi_state_lval_t)(void *)CvXSUB(cv);       \
         }                                                                   \
         return dbi_state_lval_p(aTHX);                                      \
     }                                                                       \


### PR DESCRIPTION
Was seeing this:
```
Perl.xs: In function ‘dbi_get_state’:
DBIXS.h:498:32: warning: cast between incompatible function types from ‘void (*)(PerlInterpreter *, CV *)’ {aka ‘void (*)(struct interpreter *, struct cv *)
 } to ‘dbistate_t ** (*)(PerlInterpreter *)’ {aka ‘struct dbistate_st ** (*)(struct interpreter *)’} [-Wcast-function-type]
  498 |             dbi_state_lval_p = (_dbi_state_lval_t)CvXSUB(cv);       \
      |                                ^
DBIXS.h:506:27: note: in expansion of macro ‘_DBISTATE_DECLARE_COMMON’
  506 | # define DBISTATE_DECLARE _DBISTATE_DECLARE_COMMON
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~
Perl.xs:13:1: note: in expansion of macro ‘DBISTATE_DECLARE’
   13 | DBISTATE_DECLARE;
      | ^~~~~~~~~~~~~~~~
```
