### PR TITLE
Fix !Caller2 caller loss when $^P is set

### DIFF
--- a/DBI.xs
+++ b/DBI.xs
@@ -2681,7 +2681,8 @@ dbi_caller_cop()
         if (cxix < 0) {
             break;
         }
-        if (PL_DBsub && cxix >= 0 && ccstack[cxix].blk_sub.cv == GvCV(PL_DBsub))
+        /* skip the automatic calls to &DB::sub, as perl's pp_caller does */
+        if (PL_DBsub && GvCV(PL_DBsub) && cxix >= 0 && ccstack[cxix].blk_sub.cv == GvCV(PL_DBsub))
             continue;
         cx = &ccstack[cxix];
         stashname = CopSTASHPV(cx->blk_oldcop);

--- a/t/44prof_caller.t
+++ b/t/44prof_caller.t
@@ -1,0 +1,58 @@
+#!perl -w
+$|=1;
+
+#
+# test that DBI::Profile !Caller2 still reports the caller's caller when
+# $^P is set but &DB::sub is not defined, as happens under tools such as
+# Devel::Cover (GH #177)
+#
+
+use strict;
+
+use DBI;
+use File::Basename qw(basename);
+
+use Test::More;
+
+BEGIN {
+    plan skip_all => "profiling not supported for DBI::PurePerl"
+        if $DBI::PurePerl;
+
+    plan tests => 2;
+}
+
+# log file to store profile results
+my $LOG_FILE = "test_output_profile$$.log";
+my $orig_dbi_debug = $DBI::dbi_debug;
+DBI->trace($DBI::dbi_debug, $LOG_FILE);
+END {
+    return if $orig_dbi_debug;
+    1 while unlink $LOG_FILE;
+}
+
+# simulate a tool like Devel::Cover: the debugger API is initialised
+# because $^P is set, but &DB::sub is not defined
+$^P |= 0x100;
+
+our $dbh = DBI->connect("dbi:ExampleP:", '', '', { RaiseError=>1 });
+$dbh->{Profile} = "!MethodName:!Caller2";
+
+# the "via ..." part of !Caller2 needs the profiled call to be made
+# inside a sub, eval or do FILE, so call $dbh->do from a helper file
+my $helper_file = "test_output_dbsub$$.pl";
+END { 1 while defined $helper_file && unlink $helper_file }
+open my $fh, ">", $helper_file or die "Can't create $helper_file: $!";
+print $fh qq{\$main::dbh->do("set foo=1");\n1;\n};
+close $fh or die "Can't close $helper_file: $!";
+
+do "./$helper_file" or die $@ || $!; my $line = __LINE__;
+
+my @keys = keys %{ $dbh->{Profile}{Data}{do} };
+is scalar @keys, 1, 'one profile leaf for do';
+my $this_file = basename(__FILE__);
+is $keys[0], "$helper_file line 1 via $this_file line $line",
+    '!Caller2 includes the "via" caller when $^P is set';
+
+$dbh->{Profile} = 0;
+
+1;


### PR DESCRIPTION
Fixes #177

## Summary

- `dbi_caller_cop()` in DBI.xs is a copy of perl's `pp_caller` frame walk,
  but it omits the `GvCV(PL_DBsub)` guard that core added in 2005 for the
  same bug (RT 35059, core commit f2a7f2982c).
- When `$^P` is set without `&DB::sub` being defined, as happens under
  `Devel::Cover` and similar tools, `PL_DBsub` is initialised while
  `GvCV(PL_DBsub)` is NULL.  For an eval or `do FILE` context `blk_sub.cv`
  aliases `blk_eval.old_eval_root`, which is NULL at the top level, so the
  frame was skipped as if it were a `DB::sub` call and the "via ..." part
  of `!Caller2` profile paths and trace output was silently dropped.  This
  is why `t/zvg_40profile.t` fails under `Devel::Cover`.
- Add the missing guard, matching perl core, plus a regression test that
  reproduces the failure without any external module by setting `$^P`
  directly.

## Test plan

- [x] `t/44prof_caller.t` fails before the fix, passes after (plain and
      `zvg_` Gofer variants)
- [x] `t/zvg_40profile.t` passes under `Devel::Cover` with the fix
- [x] Full suite shows no regressions (the `t/31methcache.t` failures on
      non-threaded perls are pre-existing on HEAD)