### PR TITLE
Add option to disallow UPDATE to overwrite an existingprimary  key row

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@
     * Force placeholder limit on :# and :p# too (CVE-2026-73194)
     * Limit statements to 292 Mb in preparse (CVE-2026-73193)
     * Add a security policy (issue#174)
+    * Add dbm_updatable_key attribute to DBD::DBM to configure how keys are updated
 
 1.651 - 2026-07-14, H.Merijn Brand & Robert Rothenberg
     * Fix inverted comparisons for strings in DBI::SQL::Nano  (CVE-2026-15043)

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@
     * Limit statements to 292 Mb in preparse (CVE-2026-73193)
     * Add a security policy (issue#174)
     * Add dbm_updatable_key attribute to DBD::DBM to configure how keys are updated
+    * Fix missing import in DBI::DBD::SqlEngine
 
 1.651 - 2026-07-14, H.Merijn Brand & Robert Rothenberg
     * Fix inverted comparisons for strings in DBI::SQL::Nano  (CVE-2026-15043)

--- a/lib/DBD/DBM.pm
+++ b/lib/DBD/DBM.pm
@@ -138,6 +138,7 @@ sub init_valid_attributes
                                 dbm_readonly_attrs => 1,    # DBD::DBM::db r/o attrs
                                 dbm_meta           => 1,    # DBD::DBM public access for f_meta
                                 dbm_tables         => 1,    # DBD::DBM public access for f_meta
+                                dbm_updatable_key  => 1,
                               };
     $dbh->{dbm_readonly_attrs} = {
                                    dbm_version        => 1,    # verbose DBD::DBM version
@@ -340,6 +341,11 @@ sub init_table_meta
     unless ( defined( $meta->{col_names} ) )
     {
         defined( $dbh->{dbm_cols} ) and $meta->{col_names} = $dbh->{dbm_cols};
+    }
+
+    unless ( defined( $meta->{dbm_updatable_key} ) )
+    {
+        defined( $dbh->{dbm_updatable_key} ) and $meta->{dbm_updatable_key} = $dbh->{dbm_updatable_key};
     }
 
     $self->SUPER::init_table_meta( $dbh, $meta, $table );
@@ -568,6 +574,14 @@ sub update_specific_row ($$$$)
     my $key    = shift @$origary;
     my $newkey = shift @$aryref;
     return unless ( defined $key );
+
+    if ( my $mode = $meta->{dbm_updatable_key} ) {
+        my $method = $mode == 1 ? \&carp : \&croak;
+        my $exists;
+        eval { $exists = $key ne $newkey && exists( $meta->{hash}->{$newkey} ); };
+        $exists and $method->("Row with PK '$newkey' already exists");
+    }
+
     $key eq $newkey or delete $meta->{hash}->{$key};
     my $row = ( ref($aryref) eq 'ARRAY' ) ? $aryref : [$aryref];
     $meta->{hash}->{$newkey} = $meta->{dbm_mldbm} ? $row : $row->[0];
@@ -1020,6 +1034,26 @@ SQL::Statement can benefit from the key field optimizations on
 updating and deleting rows - and here the improved where clause
 evaluation of SQL::Statement might beat DBI::SQL::Nano every time the
 where clause contains not only the key field (or more than one).
+
+=head2 Updatable Keys
+
+The default behavior is that updating a key to the same value of an
+existing key will succeed, and the existing row will be overwritten.
+
+There may be cases where this is undesirable.
+
+This behavior can now be configured, by setting C<dbm_updatable_key>
+attribute.  To emit a warning when this happens, set it to C<1>:
+
+  $dbh = DBI->connect('dbi:DBM:', undef, undef, {
+      dbm_updatable_key => 1,
+  } );
+
+To instead die when that happens, set it to C<2>:
+
+  $dbh = DBI->connect('dbi:DBM:', undef, undef, {
+      dbm_updatable_key => 2,
+  } );
 
 =head2 Supported SQL syntax
 

--- a/lib/DBI/Changes.pm
+++ b/lib/DBI/Changes.pm
@@ -48,6 +48,10 @@ Add a security policy (issue#174)
 
 Add dbm_updatable_key attribute to DBD::DBM to configure how keys are updated
 
+=item *
+
+Fix missing import in DBI::DBD::SqlEngine
+
 =back
 
 =head2 Changes in DBI 1.651 - 14 Jul 2026

--- a/lib/DBI/Changes.pm
+++ b/lib/DBI/Changes.pm
@@ -44,6 +44,10 @@ Limit statements to 292 Mb in preparse (CVE-2026-73193)
 
 Add a security policy (issue#174)
 
+=item *
+
+Add dbm_updatable_key attribute to DBD::DBM to configure how keys are updated
+
 =back
 
 =head2 Changes in DBI 1.651 - 14 Jul 2026

--- a/lib/DBI/DBD/SqlEngine.pm
+++ b/lib/DBI/DBD/SqlEngine.pm
@@ -275,6 +275,7 @@ use strict;
 use warnings;
 
 use Carp;
+use Scalar::Util qw( refaddr );
 
 if ( eval { require Clone; } )
 {

--- a/t/50dbm_simple.t
+++ b/t/50dbm_simple.t
@@ -276,7 +276,69 @@ sub do_test {
     my @tables = $sth->fetchall_arrayref;
     is_deeply( \@tables, [ [] ], "No tables delivered by table_info" );
 
+    # TODO these tests should be run using the database connection parameters
+    do_update_test( $dbh, $dtype ) unless $using_dbd_gofer;
+
     $dbh->disconnect;
+
     return 1;
 }
+
+sub do_update_test {
+    my ( $dbh, $dtype ) = @_;
+
+    for my $mode ( 0 .. 2 ) {
+
+        note "dbm_updatable_key = $mode";
+        $dbh->{dbm_updatable_key} = $mode;
+
+        my $tests = [
+            "DROP TABLE IF EXISTS brassica",                      -1,
+            "CREATE TABLE brassica (dKey INT, dVal VARCHAR(10))", '0E0',
+            "INSERT INTO  brassica VALUES (1,'neep')",            1,
+            "INSERT INTO  brassica VALUES (2,'kale')",            1,
+            "UPDATE brassica SET dKey=1 WHERE dKey=2",            \$mode, # depends on mode
+            "DROP TABLE brassica",                                -1,
+        ];
+
+        my $i = 0;
+        my ( $queries, $expected ) = part { $i++ % 2 } @{$tests};
+
+        my $idx = 0;
+        for my $sql ( @{$queries} ) {
+
+            $sql =~ s/\S*brassica/${dtype}_brassica/;    # include dbm type in table name
+
+            my $sth = $dbh->prepare($sql);
+            ok( $sth, "prepare $sql" ) or diag( $dbh->errstr || 'unknown error' );
+
+            my $expect = $expected->[$idx];
+            if ( ref($expect) ) {
+
+                $sth->{PrintError} = 0;
+
+                my $n = $sth->execute();
+
+                if ( $mode == 2 ) {
+                    ok( !$n, 'execute failed' );
+                    like $sth->errstr, qr/^Row with PK '1' already exists/, 'execpted error';
+                }
+                else {
+                    # TODO: trap warnings to test when $mode == 1
+                    is( $n, 1, 'execute' ) or diag( $sth->errstr || 'unknown error' );
+                }
+
+            }
+            else {
+                my $n = $sth->execute();
+                is( $n, $expect, 'execute' ) or diag( $sth->errstr || 'unknown error' );
+            }
+
+            $idx++;
+        }
+
+    }
+
+}
+
 1;


### PR DESCRIPTION
This adds a dbm_updatable_key attribute, with the following values:
  - 0 = no change, default behavior as is
  - 1 = warn on duplicate key but continue as usual
  - 2 = croak on duplicate key