### PR TITLE
Fix t/60preparse.t not to depend on undefined behavior of atoi()

### DIFF
--- a/DBI.xs
+++ b/DBI.xs
@@ -13,6 +13,10 @@
 
 #include "DBIXS.h"      /* DBI public interface for DBD's written in C  */
 
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+
 # if (defined(_WIN32) && (! defined(HAS_GETTIMEOFDAY)))
 #include <sys/timeb.h>
 # endif
@@ -74,6 +78,7 @@ static SV        *dbih_event       _((SV *h, const char *name, SV*, SV*));
 static int        dbih_set_attr_k  _((SV *h, SV *keysv, int dbikey, SV *valuesv));
 static SV        *dbih_get_attr_k  _((SV *h, SV *keysv, int dbikey));
 static int       dbih_sth_bind_col _((SV *sth, SV *col, SV *ref, SV *attribs));
+static int       dbi_atoi          _((const char *nptr));
 
 static int      set_err_char _((SV *h, imp_xxh_t *imp_xxh, const char *err_c, IV err_i, const char *errstr, const char *state, const char *method));
 static int      set_err_sv   _((SV *h, imp_xxh_t *imp_xxh, SV *err, SV *errstr, SV *state, SV *method));
@@ -4356,7 +4361,7 @@ preparse(SV *dbh, const char *statement, IV ps_return, IV ps_accept, void *foo)
             }
         }
         else if (isDIGIT(*src)) {   /* :1 */
-            const int pln = atoi(src);
+            const int pln = dbi_atoi(src);
 
             if (pln > 99999 || pln <= 0) {
                 char buf[99];
@@ -4442,6 +4447,21 @@ preparse(SV *dbh, const char *statement, IV ps_return, IV ps_accept, void *foo)
     SvCUR_set(new_stmt_sv, strlen(SvPVX(new_stmt_sv)));
     *SvEND(new_stmt_sv) = '\0';
     return new_stmt_sv;
+}
+
+
+/* Like atoi() but returns 2147483647 (32-bit INT_MAX) for out of range values */
+static int dbi_atoi(const char *nptr)
+{
+    long lresult;
+
+    errno = 0;
+    lresult = strtol(nptr, NULL, 10);
+    if (errno != 0 || lresult < INT_MIN || lresult > INT_MAX) {
+        /* Don't use INT_MAX in case it's not 32 bits */
+        return 2147483647;
+    }
+    return (int)lresult;
 }
 
 

--- a/t/60preparse.t
+++ b/t/60preparse.t
@@ -148,10 +148,10 @@ ok( $DBI::err );
 is( $DBI::errstr, "preparse found :p100000 which is outside the allowed range.");
 is( pp($dbh, 'a = :2147483648', DBIpp_ph_qm, DBIpp_ph_cs|DBIpp_ph_cn), undef, 'exceeds limit');
 ok( $DBI::err );
-is( $DBI::errstr, "preparse found :p-2147483648 which is outside the allowed range.");
+is( $DBI::errstr, "preparse found :p2147483647 which is outside the allowed range.");
 is( pp($dbh, 'a = :12345678987654321', DBIpp_ph_qm, DBIpp_ph_cs|DBIpp_ph_cn), undef, 'exceeds limit');
 ok( $DBI::err );
-like( $DBI::errstr, qr{^preparse found :p\d+ which is outside the allowed range.$});
+is( $DBI::errstr, "preparse found :p2147483647 which is outside the allowed range.");
 
 $dbh->disconnect;
 


### PR DESCRIPTION
Testing on i686 fails because the value returned by `atoi()` for the input string "2147483648" is not -2147483648, which is what happens to be returned on glibc on x86_64. There is no defined behavior for what `atoi()` returns for out of range values.

One way to address this is to use our own version of `atoi()` that expressly returns a known value (in this case 2147483647) when an out of range value is presented as input.

Exanple failure:
```
#   Failed test at t/60preparse.t line 151.
#          got: 'preparse found :p2147483647 which is outside the allowed range.'
#     expected: 'preparse found :p-2147483648 which is outside the allowed range.'
# Looks like you failed 1 test of 51.
t/60preparse.t .................. 
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/51 subtests 
```
