### PR TITLE
Fix integer overflow after strlen().

### DIFF
--- a/DBI.xs
+++ b/DBI.xs
@@ -4144,7 +4144,7 @@ preparse(SV *dbh, const char *statement, IV ps_return, IV ps_accept, void *foo)
         we add support for odbc escape sequences.
 */
     int idx = 1;
-    int sln;
+    STRLEN sln;
 
     char in_quote = '\0';
     char in_comment = '\0';


### PR DESCRIPTION
In preparse() the integer variable sln is used the store the return value of strlen().  By that the real length is truncated to 32 bit and made signed.  This way the overflow check sln > 306783375 can be circumvented.  Make sln of type STRLEN.